### PR TITLE
Member Page for SCE members and non-member page/ message for non members

### DIFF
--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -387,7 +387,7 @@ router.post('/getUserById', async (req, res) => {
   if (!checkIfTokenSent(req)) {
     return res.sendStatus(FORBIDDEN);
   } else if (!checkIfTokenValid(req, (
-    membershipState.OFFICER
+    membershipState.MEMBER
   ))) {
     return res.sendStatus(UNAUTHORIZED);
   }

--- a/src/Pages/Profile/MemberView/Profile.js
+++ b/src/Pages/Profile/MemberView/Profile.js
@@ -114,6 +114,14 @@ export default class Profile extends Component {
       ]
       : [
         { title: 'Become a member to access this page!', value: '' },
+        { title: '', value: '' },
+        { title: '', value: '' },
+        { title: '', value: '' },
+        { title: '', value: '' },
+        { title: '', value: '' },
+        { title: '', value: '' },
+        { title: '', value: '' },
+        { title: '', value: '' }
       ];
 
     return (

--- a/src/Pages/Profile/MemberView/Profile.js
+++ b/src/Pages/Profile/MemberView/Profile.js
@@ -110,18 +110,10 @@ export default class Profile extends Component {
             user={{ ...this.state.user, token: this.props.user.token }}
           />,
           icon: <FontAwesomeIcon icon={faLock} />
-        }
+        },
       ]
       : [
-        { title: '', value: '' },
-        { title: 'Door Code', value: '' },
-        { title: 'Joined Date', value: '' },
-        { title: 'Email', value: '' },
-        { title: 'Membership Expiration', value: '' },
-        { title: '2D Prints', value: '' },
-        { title: 'Request 3D Printing', value: '' },
-        { title: 'Sign-in with Discord', value: '' },
-        { title: 'Change Password', value: '' }
+        { title: 'Become a member to access this page!', value: '' },
       ];
 
     return (


### PR DESCRIPTION
This was done by changing the endpoint to give information to users with member membership status and above as opposed to officer. 

There is also a message for non members who want to access the member page.
nonmember:
![image](https://user-images.githubusercontent.com/73515552/208279427-1e187c14-726e-4563-a287-a660fde202c4.png)
member:
![image](https://user-images.githubusercontent.com/73515552/208279442-14055f69-8b02-4fdd-928f-f56204bdb6e6.png)
