### PR TITLE
Npm run start windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "api-test": "mocha test/api/*.js",
     "frontend-test": "mocha --require @babel/register --require ignore-styles test/frontend/*.js --exit",
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "server": "npm run dev --prefix api",
     "lint": "eslint .",
     "server-install": "npm install --prefix api",


### PR DESCRIPTION
Running npm run start has issues on windows if using the most recent Node.js.
This push is an alternative too downgrading Node.js