### PR TITLE
Os dependent hot reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ config.json
 token.json
 sheets.json
 api/config/AWS-IOT/*pem*
+.env
 
 # CSR
 *.csr

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,9 @@ services:
     volumes:
       - sce_mongodb_data_dev:/data/db
     command: 'mongod --quiet --logpath /dev/null'
+    environment:
+      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING}
+      - WATCHPACK_POLLING=${WATCHPACK_POLLING}
   sce-peripheral-api:
     container_name: sce-peripheral-api-dev
     build:
@@ -18,6 +21,8 @@ services:
       - MAIN_ENDPOINT_URL=sce-main-endpoints-dev:8080
       - DATABASE_HOST=sce-mongodb-dev
       - NODE_ENV=development
+      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING}
+      - WATCHPACK_POLLING=${WATCHPACK_POLLING}
     ports:
       - '8081:8081'
     restart: 'on-failure'
@@ -42,6 +47,8 @@ services:
       - VERIFICATION_BASE_URL=http://localhost
       - DATABASE_HOST=sce-mongodb-dev
       - NODE_ENV=development
+      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING}
+      - WATCHPACK_POLLING=${WATCHPACK_POLLING}
     ports:
         - '8082:8082'
     restart: 'on-failure'
@@ -65,6 +72,8 @@ services:
       - DISCORD_REDIRECT_URI=http://localhost/api/user/callback
       - DATABASE_HOST=sce-mongodb-dev
       - NODE_ENV=development
+      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING}
+      - WATCHPACK_POLLING=${WATCHPACK_POLLING}
     ports:
       - '8080:8080'
     restart: 'on-failure'
@@ -90,6 +99,8 @@ services:
       - REACT_APP_PERIPHERAL_API_URL=http://localhost/peripheralapi
       - REACT_APP_MAILER_API_URL=http://localhost/cloudapi
       - NODE_ENV=development
+      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING}
+      - WATCHPACK_POLLING=${WATCHPACK_POLLING}
 
     ports:
       - '3000:3000'
@@ -116,6 +127,9 @@ services:
     restart: 'on-failure'
     depends_on:
       - frontend
+    environment:
+      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING}
+      - WATCHPACK_POLLING=${WATCHPACK_POLLING}
 
 volumes:
   sce_mongodb_data_dev:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def add_alias_windows():
 # files are also being managed by windows it gets messy using the os default file watching protocal
 # the .env file will be user specific and not interfere with non-windows users
 def make_env(isWindows):
-    with open(".env", "x"):
+    with open(".env", "x") as f:
         f.write(f"CHOKIDAR_USEPOLLING={isWindows}\nWATCHPACK_POLLING={isWindows}")
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,11 @@ def add_alias_windows():
                              stderr=subprocess.STDOUT, shell = True)
 
 # This function is neccesary such that users from different operating systems can
-# both
-# 
+# both make use of hot reload
+# CHOKIDAR_USEPOLLING and WATCHPACK_POLLING are alternate methods of watching for changes on files
+# windows users need this because the docker containers are all running linux and since their
+# files are also being managed by windows it gets messy using the os default file watching protocal
+# the .env file will be user specific and not interfere with non-windows users
 def make_env(isWindows):
     f = open(".env", "x")
     f.write(f"CHOKIDAR_USEPOLLING={isWindows}\nWATCHPACK_POLLING={isWindows}")

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ def add_alias_windows():
 # files are also being managed by windows it gets messy using the os default file watching protocal
 # the .env file will be user specific and not interfere with non-windows users
 def make_env(isWindows):
-    f = open(".env", "x")
-    f.write(f"CHOKIDAR_USEPOLLING={isWindows}\nWATCHPACK_POLLING={isWindows}")
+    with open(".env", "x"):
+        f.write(f"CHOKIDAR_USEPOLLING={isWindows}\nWATCHPACK_POLLING={isWindows}")
 
 
 print('Welcome to SCE-Development Setup!\n')

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ def add_alias_windows():
     subprocess.check_call("setx ESLINT_NO_DEV_ERRORS true",
                              stderr=subprocess.STDOUT, shell = True)
 
+# This function is neccesary such that users from different operating systems can
+# both
+# 
 def make_env(isWindows):
     f = open(".env", "x")
     f.write(f"CHOKIDAR_USEPOLLING={isWindows}\nWATCHPACK_POLLING={isWindows}")
@@ -48,14 +51,16 @@ if user_os == 'Darwin' or user_os == 'Linux':
         os.system("cp api/config/config.example.json  api/config/config.json")
     if os.path.exists("src/config/config.json") == False:
         os.system("cp src/config/config.example.json  src/config/config.json")
+    if os.path.exists(".env") == False:
+        make_env(False)  
     add_alias_unix()
-    make_env(False)
 elif user_os == 'Windows':
     if os.path.exists("api\config\config.json") == False:
         os.system("copy api\config\config.example.json  api\config\config.json")
     if os.path.exists("src\config\config.json") == False:
         os.system("copy src\config\config.example.json  src\config\config.json")
+    if os.path.exists(".env") == False:
+        make_env(True)
     add_alias_windows()
-    make_env(True)
 
 print('\nSetup complete! Bye!\n')

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ def add_alias_windows():
     subprocess.check_call("setx ESLINT_NO_DEV_ERRORS true",
                              stderr=subprocess.STDOUT, shell = True)
 
+def make_env(isWindows):
+    f = open(".env", "x")
+    f.write(f"CHOKIDAR_USEPOLLING={isWindows}\nWATCHPACK_POLLING={isWindows}")
 
 print('Welcome to SCE-Development Setup!\n')
 user_os = platform.system()
@@ -46,11 +49,13 @@ if user_os == 'Darwin' or user_os == 'Linux':
     if os.path.exists("src/config/config.json") == False:
         os.system("cp src/config/config.example.json  src/config/config.json")
     add_alias_unix()
+    make_env(False)
 elif user_os == 'Windows':
     if os.path.exists("api\config\config.json") == False:
         os.system("copy api\config\config.example.json  api\config\config.json")
     if os.path.exists("src\config\config.json") == False:
         os.system("copy src\config\config.example.json  src\config\config.json")
     add_alias_windows()
+    make_env(True)
 
 print('\nSetup complete! Bye!\n')


### PR DESCRIPTION
Creates an environment variable folder based on your terminal's operating system when you run setup.py. The environment variables modify the behavior of hot reload. Without the two environment variables running a Linux-based docker image on a Windows device causes issues because the default Linux file watching is not compatible with the file system of the device. Because the files are hosted on the device and not in the Linux-based docker image, windows users need to override the default file watching necessary for hot reload.
If you are using a Mac or Linux-based device the Python script will set the environment variables to false (the default) causing nothing to change.