### PR TITLE
Use environment variables for Peripheral API URLs

### DIFF
--- a/api/peripheral_api/routes/Cleezy.js
+++ b/api/peripheral_api/routes/Cleezy.js
@@ -7,10 +7,9 @@ const {
 } = require('../../util/token-verification');
 const {
   OK,
-  BAD_REQUEST,
   UNAUTHORIZED,
   FORBIDDEN,
-  NOT_FOUND,
+  SERVER_ERROR,
 } = require('../../util/constants').STATUS_CODES;
 const logger = require('../../util/logger');
 const { Cleezy } = require('../../config/config.json');
@@ -46,7 +45,7 @@ router.get('/listAll', async (req, res) => {
     if (err.response && err.response.data) {
       res.status(err.response.status).json({ error: err.response.data });
     } else {
-      res.status(500).json({ error: 'Failed to list URLs' });
+      res.status(SERVER_ERROR).json({ error: 'Failed to list URLs' });
     }
   }
 });
@@ -77,12 +76,13 @@ router.post('/deleteUrl', async (req, res) => {
     return res.sendStatus(UNAUTHORIZED);
   }
   const { alias } = req.body;
-  const response = await axios
+  axios
     .post(CLEEZY_URL + '/delete/' + alias)
-    .then(response => {
-      res.json({ status: response.status });
+    .then(() => {
+      res.sendStatus(OK);
     })
     .catch(err => {
+      logger.error('/deleteUrl had an error', err);
       res.status(err.response.status).json({ error: err.response.status });
     });
 });

--- a/api/peripheral_api/routes/Printer.js
+++ b/api/peripheral_api/routes/Printer.js
@@ -15,7 +15,7 @@ const {
   PRINTING = {}
 } = require('../../config/config.json');
 
-// see https://github.com/SCE-Development/Quasar/blob/65151f81ba4375069c5b851d241f462ff6e09f13/docker-compose.dev.yml#L11
+// see https://github.com/SCE-Development/Quasar/tree/dev/docker-compose.dev.yml#L11
 let PRINTER_URL = process.env.PRINTER_URL
   || 'http://localhost:14000';
 

--- a/api/peripheral_api/routes/Printer.js
+++ b/api/peripheral_api/routes/Printer.js
@@ -8,11 +8,16 @@ const {
 const {
   OK,
   UNAUTHORIZED,
-  NOT_FOUND
+  NOT_FOUND,
+  SERVER_ERROR,
 } = require('../../util/constants').STATUS_CODES;
 const {
   PRINTING = {}
 } = require('../../config/config.json');
+
+// see https://github.com/SCE-Development/Quasar/blob/65151f81ba4375069c5b851d241f462ff6e09f13/docker-compose.dev.yml#L11
+let PRINTER_URL = process.env.PRINTER_URL
+  || 'http://localhost:14000';
 
 const router = express.Router();
 
@@ -26,7 +31,7 @@ router.get('/healthCheck', async (req, res) => {
     return res.sendStatus(OK);
   }
   await axios
-    .get('http://host.docker.internal:14000/healthcheck/printer')
+    .get(PRINTER_URL + '/healthcheck/printer')
     .then(() => {
       return res.sendStatus(OK);
     })
@@ -52,7 +57,7 @@ router.post('/sendPrintRequest', async (req, res) => {
 
   const { raw, copies, pageRanges } = req.body;
   axios
-    .post('http://host.docker.internal:14000/print', {
+    .post(PRINTER_URL + '/print', {
       raw,
       copies,
       pageRanges,
@@ -60,8 +65,8 @@ router.post('/sendPrintRequest', async (req, res) => {
     .then(() => {
       res.sendStatus(OK);
     }).catch((err) => {
-      logger.error('had an error: ', err);
-      res.sendStatus(500);
+      logger.error('/sendPrintRequest had an error: ', err);
+      res.sendStatus(SERVER_ERROR);
     });
 });
 

--- a/api/peripheral_api/util/LedSign.js
+++ b/api/peripheral_api/util/LedSign.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const logger = require('../../util/logger');
 
 
-// see https://github.com/SCE-Development/rpi-led-controller/blob/4005181f4e8e80ddfb045a81de66bbfe8fd4718e/server.py#L126
+// see https://github.com/SCE-Development/rpi-led-controller/tree/master/server.py#L126
 let LED_SIGN_URL = process.env.LED_SIGN_URL
   || 'http://localhost';
 
@@ -28,7 +28,7 @@ let LED_SIGN_URL = process.env.LED_SIGN_URL
 async function updateSign(data) {
   return new Promise((resolve) => {
     axios
-      .post(LED_SIGN_URL+ '/api/update-sign', data)
+      .post(LED_SIGN_URL + '/api/update-sign', data)
       .then(() => {
         resolve(true);
       }).catch((err) => {
@@ -45,7 +45,7 @@ async function updateSign(data) {
 async function turnOffSign() {
   return new Promise((resolve) => {
     axios
-      .get(LED_SIGN_URL+ '/api/turn-off')
+      .get(LED_SIGN_URL + '/api/turn-off')
       .then(() => {
         resolve(true);
       }).catch((err) => {
@@ -76,8 +76,8 @@ async function turnOffSign() {
 async function healthCheck() {
   return new Promise((resolve) => {
     axios
-      .get(LED_SIGN_URL+ '/api/health-check')
-      .then(({data}) => {
+      .get(LED_SIGN_URL + '/api/health-check')
+      .then(({ data }) => {
         resolve(data);
       }).catch((err) => {
         logger.error('healthCheck had an error: ', err);

--- a/api/peripheral_api/util/LedSign.js
+++ b/api/peripheral_api/util/LedSign.js
@@ -1,6 +1,11 @@
 const axios = require('axios');
 const logger = require('../../util/logger');
 
+
+// see https://github.com/SCE-Development/rpi-led-controller/blob/4005181f4e8e80ddfb045a81de66bbfe8fd4718e/server.py#L126
+let LED_SIGN_URL = process.env.LED_SIGN_URL
+  || 'http://localhost';
+
 /**
  * These functions are meant only for use in production, where the
  * LED sign can be reached from Core-v4 through an SSH tunnel. Want
@@ -23,7 +28,7 @@ const logger = require('../../util/logger');
 async function updateSign(data) {
   return new Promise((resolve) => {
     axios
-      .post('http://host.docker.internal:11000/api/update-sign', data)
+      .post(LED_SIGN_URL+ '/api/update-sign', data)
       .then(() => {
         resolve(true);
       }).catch((err) => {
@@ -40,7 +45,7 @@ async function updateSign(data) {
 async function turnOffSign() {
   return new Promise((resolve) => {
     axios
-      .get('http://host.docker.internal:11000/api/turn-off')
+      .get(LED_SIGN_URL+ '/api/turn-off')
       .then(() => {
         resolve(true);
       }).catch((err) => {
@@ -71,7 +76,7 @@ async function turnOffSign() {
 async function healthCheck() {
   return new Promise((resolve) => {
     axios
-      .get('http://host.docker.internal:11000/api/health-check')
+      .get(LED_SIGN_URL+ '/api/health-check')
       .then(({data}) => {
         resolve(data);
       }).catch((err) => {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,9 @@ services:
       dockerfile: ./peripheral_api/Dockerfile.dev
     environment:
       - MAIN_ENDPOINT_URL=sce-main-endpoints-dev:8080
+      - CLEEZY_URL=http://host.docker.internal:8000
+      - PRINTER_URL=http://host.docker.internal:14000
+      - LED_SIGN_URL=http://host.docker.internal:11000
       - DATABASE_HOST=sce-mongodb-dev
       - NODE_ENV=development
       - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     environment:
       - MAIN_ENDPOINT_URL=sce-main-endpoints:8080
       - CLEEZY_URL=http://cleezy-app.sce:8000
+      - PRINTER_URL=http://host.docker.internal:14000
+      - LED_SIGN_URL=http://host.docker.internal:11000
       - DATABASE_HOST=sce-mongodb
       - NODE_ENV=production
     restart: 'on-failure'


### PR DESCRIPTION
every service behind an ssh tunnel now has the url specified as an environment variable

![SCE Website Architecture drawio](https://github.com/SCE-Development/Clark/assets/36345325/7419cb83-b627-48f4-9f31-f2bb694a0906)