### PR TITLE
fix date logic for resetting users' pages printed

### DIFF
--- a/api/main_endpoints/routes/Auth.js
+++ b/api/main_endpoints/routes/Auth.js
@@ -23,39 +23,7 @@ const {
 } = require('../../util/constants').STATUS_CODES;
 const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
 const {sendVerificationEmail} = require('../util/emailHelpers');
-const { userWithEmailExists } = require('../util/userHelpers');
-
-
-/**
- * Check if a Sunday has passed in between the user's last login date and
- * today's date. This is because the printing pages reset every Sunday.
- * @param {Date} lastLogin the date when the user last logged in
- * @returns {Boolean} returns boolean representing if the pages need to be
- * reset
- */
-function checkIfPageCountResets(lastLogin) {
-  if (!lastLogin) return false;
-
-  let date = new Date(lastLogin.getTime());
-  const newDate = new Date();
-  let isSunday = false;
-
-  // If last login was today, don't check.
-  if (date.toDateString() === newDate.toDateString()) {
-    return false;
-  }
-
-  while (date <= newDate) {
-    let day = date.getDay();
-    isSunday = (day === 0);
-    if (isSunday) {
-      return true;
-    }
-    date.setDate(date.getDate() + 1);
-  }
-
-  return false;
-}
+const { userWithEmailExists, checkIfPageCountResets } = require('../util/userHelpers');
 
 // Register a member
 router.post('/register', async (req, res) => {

--- a/api/main_endpoints/util/userHelpers.js
+++ b/api/main_endpoints/util/userHelpers.js
@@ -165,11 +165,9 @@ function checkIfPageCountResets(lastLogin) {
   // by mocking, we can have `new Date` return
   // tomorrow, last week etc
   const now = new Date();
-  
   const week = 7 * 24 * 60 * 60 * 1000; // a week in milliseconds
-  
-  // if users last login was >= week ago OR there was a sunday between the last login and now, reset is allowed
-  if (now.getTime() - oldDate.getTime() >= week || oldDate.getDay() > now.getDay()) { 
+  // reset if users last login was >= week ago OR there was a sunday between the last login and now
+  if (now.getTime() - oldDate.getTime() >= week || oldDate.getDay() > now.getDay()) {
     return true;
   }
 

--- a/api/main_endpoints/util/userHelpers.js
+++ b/api/main_endpoints/util/userHelpers.js
@@ -173,5 +173,10 @@ function checkIfPageCountResets(lastLogin) {
   return lastLoginWasOverOneWeekAgo || aSundayHasPassedSinceLastLogin;
 }
 
-
-
+module.exports = {
+  registerUser,
+  getMemberExpirationDate,
+  hashPassword,
+  userWithEmailExists,
+  checkIfPageCountResets,
+};

--- a/api/main_endpoints/util/userHelpers.js
+++ b/api/main_endpoints/util/userHelpers.js
@@ -165,21 +165,13 @@ function checkIfPageCountResets(lastLogin) {
   // by mocking, we can have `new Date` return
   // tomorrow, last week etc
   const now = new Date();
-  const oneWeekInMilliseconds = 7 * 24 * 60 * 60 * 1000; // a week in milliseconds
+  const oneWeekInMilliseconds = 7 * 24 * 60 * 60 * 1000;
   // reset if users last login was >= week ago OR there was a sunday between the last login and now
-  if (now.getTime() - oldDate.getTime() >= oneWeekInMilliseconds
-  || oldDate.getDay() > now.getDay()) {
-    return true;
-  }
+  const lastLoginWasOverOneWeekAgo  = now.getTime() - oldDate.getTime() >= oneWeekInMilliseconds;
+  const aSundayHasPassedSinceLastLogin = oldDate.getDay() > now.getDay();
 
-  return false;
+  return lastLoginWasOverOneWeekAgo || aSundayHasPassedSinceLastLogin;
 }
 
 
-module.exports = {
-  registerUser,
-  getMemberExpirationDate,
-  hashPassword,
-  userWithEmailExists,
-  checkIfPageCountResets,
-};
+

--- a/api/main_endpoints/util/userHelpers.js
+++ b/api/main_endpoints/util/userHelpers.js
@@ -165,9 +165,10 @@ function checkIfPageCountResets(lastLogin) {
   // by mocking, we can have `new Date` return
   // tomorrow, last week etc
   const now = new Date();
-  const week = 7 * 24 * 60 * 60 * 1000; // a week in milliseconds
+  const oneWeekInMilliseconds = 7 * 24 * 60 * 60 * 1000; // a week in milliseconds
   // reset if users last login was >= week ago OR there was a sunday between the last login and now
-  if (now.getTime() - oldDate.getTime() >= week || oldDate.getDay() > now.getDay()) {
+  if (now.getTime() - oldDate.getTime() >= oneWeekInMilliseconds
+  || oldDate.getDay() > now.getDay()) {
     return true;
   }
 

--- a/api/main_endpoints/util/userHelpers.js
+++ b/api/main_endpoints/util/userHelpers.js
@@ -166,20 +166,10 @@ function checkIfPageCountResets(lastLogin) {
   // tomorrow, last week etc
   const now = new Date();
   
-  // If last login was today, don't check (page count won't reset)
-  // if (oldDate.toDateString() === now.toDateString()) {
-  //   return false;
-  // }
-
   const week = 7 * 24 * 60 * 60 * 1000; // a week in milliseconds
   
-  // if users last login was >= week ago, reset is allowed
-  if (now.getTime() - oldDate.getTime() >= week) {
-    return true;
-  }
-
-  // otherwise, if there was a sunday between the last login and now, reset
-  if (oldDate.getDay() >= now.getDay()) {
+  // if users last login was >= week ago OR there was a sunday between the last login and now, reset is allowed
+  if (now.getTime() - oldDate.getTime() >= week || oldDate.getDay() > now.getDay()) { 
     return true;
   }
 

--- a/api/main_endpoints/util/userHelpers.js
+++ b/api/main_endpoints/util/userHelpers.js
@@ -147,10 +147,50 @@ function hashPassword(password) {
   });
 }
 
+/**
+ * Check if a Sunday has passed in between the user's last login date and
+ * today's date. This is because the printing pages reset every Sunday.
+ * @param {Date} lastLogin the date when the user last logged in
+ * @returns {Boolean} returns boolean representing if the pages need to be
+ * reset
+ */
+function checkIfPageCountResets(lastLogin) {
+  if (!lastLogin) return false;
+
+  let oldDate = new Date(lastLogin.getTime());
+
+  // this returns "right now" when called
+  // to unit test, we mock when "right now" is
+  //
+  // by mocking, we can have `new Date` return
+  // tomorrow, last week etc
+  const now = new Date();
+  
+  // If last login was today, don't check (page count won't reset)
+  // if (oldDate.toDateString() === now.toDateString()) {
+  //   return false;
+  // }
+
+  const week = 7 * 24 * 60 * 60 * 1000; // a week in milliseconds
+  
+  // if users last login was >= week ago, reset is allowed
+  if (now.getTime() - oldDate.getTime() >= week) {
+    return true;
+  }
+
+  // otherwise, if there was a sunday between the last login and now, reset
+  if (oldDate.getDay() >= now.getDay()) {
+    return true;
+  }
+
+  return false;
+}
+
 
 module.exports = {
   registerUser,
   getMemberExpirationDate,
   hashPassword,
   userWithEmailExists,
+  checkIfPageCountResets,
 };

--- a/test/api/Auth.js
+++ b/test/api/Auth.js
@@ -193,40 +193,40 @@ describe('Auth', () => {
   });
 
   describe('checkIfPageCountResets()', () => {
-    it('Should reset user\'s page count when last login was over 7 days ago', async() => {
-      // mock current day to January 10th, 2023 (Tuesday)
-      const mockCurrentDate = mockDayMonthAndYear(10, 0, 2023);
-      // mock last login to January 1st, 2023 (Sunday)
-      const mockLastLogin = new Date(2023, 0, 1);
-      
-      const result = checkIfPageCountResets(mockLastLogin);
-      expect(result).to.be.true;
-    });
+    it('Should reset user\'s page count when last login was over 7 days ago',
+      async () => {
+        // mock current day to January 10th, 2023 (Tuesday)
+        const mockCurrentDate = mockDayMonthAndYear(10, 0, 2023);
+        // mock last login to January 1st, 2023 (Sunday)
+        const mockLastLogin = new Date(2023, 0, 1);
+        const result = checkIfPageCountResets(mockLastLogin);
+        expect(result).to.be.true;
+      });
 
-    it('Should reset user\'s page count when there\s a Sunday between last login and now', async() => {
-      // mock current day to January 8th, 2023 (Sunday)
-      const mockCurrentDate = mockDayMonthAndYear(9, 0, 2023);
-      // mock last login to January 7th, 2023 (Saturday)
-      const mockLastLogin = new Date(2023, 0, 7);
-      
-      const result = checkIfPageCountResets(mockLastLogin);
-      expect(result).to.be.true;
-    });
+    it('Should reset user\'s page count when there\s a Sunday between last login and now',
+      async () => {
+        // mock current day to January 8th, 2023 (Sunday)
+        const mockCurrentDate = mockDayMonthAndYear(9, 0, 2023);
+        // mock last login to January 7th, 2023 (Saturday)
+        const mockLastLogin = new Date(2023, 0, 7);
+        const result = checkIfPageCountResets(mockLastLogin);
+        expect(result).to.be.true;
+      });
 
-    it('Should not reset user\'s page count when last login was less than 7 days ago and there isn\'t a Sunday between logins', async() => {
+    it('Should not reset user\'s page count when last login was less than 7 days ago ' +
+      'and there isn\'t a Sunday between logins', async () => {
       // mock current day to January 2nd, 2023 (Monday)
       const mockCurrentDate = mockDayMonthAndYear(2, 0, 2023);
       // mock last login to January 1st, 2023 (Sunday)
       const mockLastLogin = new Date(2023, 0, 1);
-      
       const result = checkIfPageCountResets(mockLastLogin);
       expect(result).to.be.false;
     });
 
-    it('Should not reset user\'s page count if today is Sunday, user has logged in once, and user logs in a second time', async() => {
+    it('Should not reset user\'s page count if today is Sunday, user has logged in once, ' +
+      'and user logs in a second time', async () => {
       const mockCurrentDate = mockDayMonthAndYear(1, 0, 2023);
       const mockLastLogin = new Date(2023, 0, 1);
-      
       const result = checkIfPageCountResets(mockLastLogin);
       expect(result).to.be.false;
     });

--- a/test/api/Auth.js
+++ b/test/api/Auth.js
@@ -213,18 +213,18 @@ describe('Auth', () => {
       expect(result).to.be.true;
     });
 
-    it('Should reset user\'s page count when users log in on a Sunday', async() => {
-      const mockCurrentDate = mockDayMonthAndYear(1, 0, 2023);
-      const mockLastLogin = new Date(2023, 0, 1);
-      
-      const result = checkIfPageCountResets(mockLastLogin);
-      expect(result).to.be.true;
-    });
-
     it('Should not reset user\'s page count when last login was less than 7 days ago and there isn\'t a Sunday between logins', async() => {
       // mock current day to January 2nd, 2023 (Monday)
       const mockCurrentDate = mockDayMonthAndYear(2, 0, 2023);
       // mock last login to January 1st, 2023 (Sunday)
+      const mockLastLogin = new Date(2023, 0, 1);
+      
+      const result = checkIfPageCountResets(mockLastLogin);
+      expect(result).to.be.false;
+    });
+
+    it('Should not reset user\'s page count if today is Sunday, user has logged in once, and user logs in a second time', async() => {
+      const mockCurrentDate = mockDayMonthAndYear(1, 0, 2023);
       const mockLastLogin = new Date(2023, 0, 1);
       
       const result = checkIfPageCountResets(mockLastLogin);

--- a/test/api/Auth.js
+++ b/test/api/Auth.js
@@ -193,7 +193,7 @@ describe('Auth', () => {
   });
 
   describe('checkIfPageCountResets()', () => {
-    it('Should reset user\'s page count when last login was over 7 days ago',
+    it('Should reset page count when the last login was over 7 days ago',
       async () => {
         // mock current day to January 10th, 2023 (Tuesday)
         const mockCurrentDate = mockDayMonthAndYear(10, 0, 2023);
@@ -203,7 +203,7 @@ describe('Auth', () => {
         expect(result).to.be.true;
       });
 
-    it('Should reset user\'s page count when there\s a Sunday between last login and now',
+    it('Should reset page count when there is a Sunday between last login and now',
       async () => {
         // mock current day to January 8th, 2023 (Sunday)
         const mockCurrentDate = mockDayMonthAndYear(9, 0, 2023);
@@ -213,8 +213,8 @@ describe('Auth', () => {
         expect(result).to.be.true;
       });
 
-    it('Should not reset user\'s page count when last login was less than 7 days ago ' +
-      'and there isn\'t a Sunday between logins', async () => {
+    it('Should not reset page count when the last login was less than 7 days ago ' +
+      'and there is no Sunday between logins', async () => {
       // mock current day to January 2nd, 2023 (Monday)
       const mockCurrentDate = mockDayMonthAndYear(2, 0, 2023);
       // mock last login to January 1st, 2023 (Sunday)
@@ -223,7 +223,7 @@ describe('Auth', () => {
       expect(result).to.be.false;
     });
 
-    it('Should not reset user\'s page count if today is Sunday, user has logged in once, ' +
+    it('Should not reset page count if today is Sunday, user has logged in once, ' +
       'and user logs in a second time', async () => {
       const mockCurrentDate = mockDayMonthAndYear(1, 0, 2023);
       const mockLastLogin = new Date(2023, 0, 1);

--- a/test/util/mocks/Date.js
+++ b/test/util/mocks/Date.js
@@ -4,6 +4,22 @@ const sinon = require('sinon');
 let clock = null;
 
 /**
+ * Mock current time to desired day, month and year
+ * @param {Number} day - day to mock
+ * @param {Number} month - month to mock
+ * @param {Number} year - month to mock
+ */
+function mockDayMonthAndYear(day, month, year) {
+  clock = sinon.useFakeTimers({
+    now: new Date(year, month, day),
+    toFake: [
+      'setTimeout', 'clearTimeout', 'setImmediate', 'clearImmediate',
+      'setInterval', 'clearInterval', 'Date'
+    ],
+  });
+}
+
+/**
  * Mock current time to desired month and year
  * @param {Number} month - month to mock
  * @param {Number} year - month to mock
@@ -34,4 +50,4 @@ function revertClock() {
   if (clock) clock.restore();
 }
 
-module.exports = { mockMonthAndYear, mockMonth, revertClock };
+module.exports = { mockDayMonthAndYear, mockMonthAndYear, mockMonth, revertClock };


### PR DESCRIPTION
removed old resetting logic
added proper logic to handle resetting a users' pages printed on Sundays (when user's last login was 7+ days ago or a Sunday passed in between logins)

added function to mock day, month, and year
added tests to check reset logic

resolves #1323 