### PR TITLE
Add TransitPredictionsPage to Clark

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,11 +47,18 @@ http {
           proxy_pass http://cleezy-nginx.sce;
         }
         
-        location ~ /transit/(.*)$ {
+        location ~ ^/transit/ {
             resolver 127.0.0.11 valid=15s;
-            proxy_set_header Host $host;
-            proxy_pass http://sceta-nginx.sce;
-            rewrite /transit/(.*) /$1 break;
+
+            proxy_set_header   Host $host;
+            set $upstream http://sceta-nginx.sce;
+            proxy_pass $upstream;
+
+            rewrite ^/transit(.*)$ $1 break;
+        }   
+
+        location ~ ^/transit$ {
+            return 302 $scheme://$http_host/transit/;
         }
 
         #Load balancer

--- a/nginx.conf
+++ b/nginx.conf
@@ -47,8 +47,11 @@ http {
           proxy_pass http://cleezy-nginx.sce;
         }
         
-        location ~ /transit {
-          proxy_pass http://sceta-nginx.sce;
+        location ~ /transit/(.*)$ {
+            resolver 127.0.0.11 valid=15s;
+            proxy_set_header Host $host;
+            proxy_pass http://sceta-nginx.sce;
+            rewrite /transit/(.*) /$1 break;
         }
 
         #Load balancer

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,6 +46,10 @@ http {
         location ~ /s/(.*)$ {
           proxy_pass http://cleezy-nginx.sce;
         }
+        
+        location ~ /sceta {
+          proxy_pass http://sceta-nginx.sce;
+        }
 
         #Load balancer
         location /api {

--- a/nginx.conf
+++ b/nginx.conf
@@ -47,7 +47,7 @@ http {
           proxy_pass http://cleezy-nginx.sce;
         }
         
-        location ~ /sceta {
+        location ~ /transit {
           proxy_pass http://sceta-nginx.sce;
         }
 


### PR DESCRIPTION
adds new TransitPredictionsPage (/transits) + API to get data from SCEta

View of entire page (zoomed out):
![image](https://github.com/SCE-Development/Clark/assets/59713070/da0763b5-9159-47e5-8842-33535e425feb)

