### PR TITLE
Fix invalid `for` attribute on label elements in EmailPreferences.js

### DIFF
--- a/src/Pages/EmailPreferences/EmailPreferences.js
+++ b/src/Pages/EmailPreferences/EmailPreferences.js
@@ -117,7 +117,7 @@ export default function EmailPreferencesPage(props) {
                 className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
                 onChange={() => setIsOptedIntoEmails(true)}
               />
-              <label for="default-radio-1" className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">
+              <label htmlFor="default-radio-1" className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">
                 {' '}I would like to continue to recieve club update emails from SCE
               </label>
             </div>
@@ -130,7 +130,7 @@ export default function EmailPreferencesPage(props) {
                 className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
                 onChange={() => setIsOptedIntoEmails(false)}
               />
-              <label for="default-radio-2" className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">
+              <label htmlFor="default-radio-2" className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">
                 {' '}No thanks, I would like to unsubscribe from all emails (best choice)
               </label>
             </div>


### PR DESCRIPTION
JSX requires `htmlFor` instead of `for`. At runtime, using the raw HTML attribute `for` name triggers a React DOM property warning.