### PR TITLE
Allow bulk creation of SCE events using CSV files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "mongoose": "^5.11.18",
         "multer": "^1.4.5-lts.1",
         "nodemailer": "^6.9.5",
+        "papaparse": "^5.5.4",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
         "pdf-lib": "^1.16.0",
@@ -14965,6 +14966,12 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
+      "integrity": "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==",
+      "license": "MIT"
     },
     "node_modules/param-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mongoose": "^5.11.18",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.5",
+    "papaparse": "^5.5.4",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "pdf-lib": "^1.16.0",

--- a/src/Components/DecisionModal/ConfirmationModal.js
+++ b/src/Components/DecisionModal/ConfirmationModal.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
 export default function ConfirmationModal(props) {
-  const { headerText, bodyText, handleConfirmation, open, handleCancel = () => {}, confirmClassAddons = '' } = props;
+  const { headerText, bodyText, handleConfirmation, open, handleCancel = () => {}, confirmClassAddons = '', hideConfirmButton = false, } = props;
 
   const confirmText = props.confirmText || 'Confirm';
   const cancelText = props.cancelText || 'Cancel';
@@ -22,9 +22,11 @@ export default function ConfirmationModal(props) {
 
           <form method="dialog">
             <div className="px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
-              <button onClick={handleConfirmation} className={`btn inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm ${confirmClassAddons} sm:ml-3 sm:w-auto`}>
-                {confirmText}
-              </button>
+              {!hideConfirmButton && (
+                <button onClick={handleConfirmation} className={`btn inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm ${confirmClassAddons} sm:ml-3 sm:w-auto`}>
+                  {confirmText}
+                </button>
+              )}
               <button onClick={handleCancel} className="btn mt-3 inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold shadow-sm ring-1 ring-inset sm:mt-0 sm:w-auto">
                 {cancelText}
               </button>

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -93,7 +93,7 @@ export default function CreateEventPage() {
   const [headersArray, setHeadersArray] = useState([]);
   const [values, setValues] = useState([]);
   const [confirmModal, setConfirmModal] = useState(false);
-  const [modalWarningMessage, setModalWarningMessage] = useState('');
+  const [modalErrorMessage, setModalErrorMessage] = useState('');
   const debounceRef = useRef(null);
   const isFileUpload = useRef(false);
 
@@ -305,6 +305,15 @@ export default function CreateEventPage() {
     'Max Attendees', 'Waitlist', 'Publish Status', 'Visibility', 'Publish Date',
   ];
 
+  function showFileErrorModal(modalMessage) {
+    setFileData([]);
+    setHeadersArray([]);
+    setValues([]);
+    setModalErrorMessage(modalMessage);
+    setConfirmModal(true);
+    isFileUpload.current = false;
+  }
+
   function handleFileUpload(event) {
     const maxFileSize = 10 * 1024 * 1024;
     const file = event.target.files[0];
@@ -312,7 +321,7 @@ export default function CreateEventPage() {
     if (!file) return;
 
     if (file.size > maxFileSize) {
-      setModalWarningMessage(`File size is ${file.size} and exceeds the 10MB limit.`);
+      setModalErrorMessage(`File size is ${file.size} and exceeds the 10MB limit.`);
       setConfirmModal(true);
       event.target.value = '';
       return;
@@ -336,31 +345,22 @@ export default function CreateEventPage() {
           let emptyValueCounter = 0;
 
           if(row.length < required_number_of_columns) {
-            setFileData([]);
-            setHeadersArray([]);
-            setValues([]);
             const actualHeaders = (headersArray[0] || []).map((h) => h.trim());
             const missingHeaders = EXPECTED_HEADERS.filter((h) => !actualHeaders.includes(h));
-            setModalWarningMessage(`Missing required columns: ${missingHeaders.join(', ')}`);
-            setConfirmModal(true);
-            isFileUpload.current = false;
+            showFileErrorModal(`Missing required columns: ${missingHeaders.join(', ')}`);
             return;
           }
           let missingElements = [];
           for (let i = 0; i < row.length; i++) {
+            // index 9 is treated different because it is the only one that can be accepted as empty
             if (i !== 9 && row[i] === '') {
               emptyValueCounter++;
               missingElements.push(i);
             }
           }
           if (emptyValueCounter > 0) {
-            setFileData([]);
-            setHeadersArray([]);
-            setValues([]);
             const missingColumnNames = missingElements.map((i) => headersArray[0][i]);
-            setModalWarningMessage(`Missing required elements: ${missingColumnNames.join(', ')}`);
-            setConfirmModal(true);
-            isFileUpload.current = true;
+            showFileErrorModal(`Missing required columns: ${missingColumnNames.join(', ')}`);
             return;
           }
         }
@@ -376,7 +376,7 @@ export default function CreateEventPage() {
 
   async function handleFileCreateEvent() {
     if (values.length === 0) {
-      setModalWarningMessage('No valid rows to create. Please upload a valid CSV file.');
+      setModalErrorMessage('No valid rows to create. Please upload a valid CSV file.');
       setConfirmModal(true);
       return;
     }
@@ -477,8 +477,8 @@ export default function CreateEventPage() {
         setPublishDate,
         confirmModal,
         setConfirmModal,
-        modalWarningMessage,
-        setModalWarningMessage,
+        modalErrorMessage,
+        setModalErrorMessage,
       }}
       questionActions={{
         questions,

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -88,7 +88,6 @@ export default function CreateEventPage() {
   const [adminSearching, setAdminSearching] = useState(false);
   const [submitError, setSubmitError] = useState('');
   const [submitting, setSubmitting] = useState(false);
-  const [fileTable, setFileTable] = useState([]);
   const [fileData, setFileData] = useState([]);
   const [headersArray, setHeadersArray] = useState([]);
   const [values, setValues] = useState([]);
@@ -104,6 +103,44 @@ export default function CreateEventPage() {
     () => eventAdmins.map((admin) => String(admin._id)),
     [eventAdmins],
   );
+
+  const CSV_COLUMN = Object.freeze({
+    EVENT_NAME: 0,
+    DATE: 1,
+    TIME: 2,
+    LOCATION: 3,
+    DESCRIPTION: 4,
+    MAX_ATTENDEES: 5,
+    WAITLIST: 6,
+    STATUS: 7,
+    VISIBILITY: 8,
+    PUBLISH_DATE: 9,
+  });
+
+  const EXPECTED_HEADERS = [
+    'Event Name', 'Date', 'Time', 'Location', 'Description',
+    'Max Attendees', 'Waitlist', 'Publish Status', 'Visibility', 'Publish Date',
+  ];
+
+  const EXAMPLE_CSV_ROWS = [
+    EXPECTED_HEADERS,
+    ['Example Name', 'yyyy-mm-dd', 'hh:mm PM', 'Example Location', 'Example description', '20', '5', 'published', 'public', 'yyyy-mm-dd'],
+    ['Cookie party', '2026-08-21', '6:00 AM', 'Engineering Building', 'Eat cookies', '-1', '-1', 'draft', 'public', ''],
+    ['', '', '', '', '', '', '', '', '', ''],
+    ['Note: max attendees: -1 for unlimited, waitlist: -1 to disable, publish date: leave empty if none. Visibility can only be public atm. Do not touch row one and start at row two. DELETE THIS BOX BEFORE SUBMITTING', '', '', '', '', '', '', '', '', ''],
+  ];
+
+  function toCsvCell(cell) {
+    const str = String(cell);
+    if (/[",\n]/.test(str)) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  }
+
+  const EXAMPLE_CSV = EXAMPLE_CSV_ROWS
+    .map((row) => row.map(toCsvCell).join(','))
+    .join('\r\n');
 
   useEffect(() => {
     if (!adminId || allOrgAdminsCanEdit) return;
@@ -300,32 +337,6 @@ export default function CreateEventPage() {
     );
   }
 
-  const EXPECTED_HEADERS = [
-    'Event Name', 'Date', 'Time', 'Location', 'Description',
-    'Max Attendees', 'Waitlist', 'Publish Status', 'Visibility', 'Publish Date',
-  ];
-
-  const EXAMPLE_CSV_ROWS = [
-    EXPECTED_HEADERS,
-    ['Example Name', 'yyyy-mm-dd', 'hh:mm PM', 'Example Location', 'Example description', '20', '5', 'published', 'public', 'yyyy-mm-dd'],
-    ['Cookie party', '2026-08-21', '6:00 AM', 'Engineering Building', 'Eat cookies', '-1', '-1', 'draft', 'public', ''],
-    ['', '', '', '', '', '', '', '', '', ''],
-    ['Note: max attendees: -1 for unlimited, waitlist: -1 to disable, publish date: leave empty if none. Visibility can only be public atm. Do not touch row one and start at row two. DELETE THIS BOX BEFORE SUBMITTING', '', '', '', '', '', '', '', '', ''],
-  ];
-
-  /** Only quotes a cell when it actually needs it (contains a comma, quote, or newline). */
-  function toCsvCell(cell) {
-    const str = String(cell);
-    if (/[",\n]/.test(str)) {
-      return `"${str.replace(/"/g, '""')}"`;
-    }
-    return str;
-  }
-
-  const EXAMPLE_CSV = EXAMPLE_CSV_ROWS
-    .map((row) => row.map(toCsvCell).join(','))
-    .join('\r\n');
-
   function handleDownloadExampleCsv() {
     const blob = new Blob([EXAMPLE_CSV], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
@@ -348,7 +359,7 @@ export default function CreateEventPage() {
   }
 
   function handleFileUpload(event) {
-    const maxFileSize = 10 * 1024 * 1024;
+    const maxFileSize = 10 * 1024 * 1024; // 10MB
     const file = event.target.files[0];
 
     if (!file) return;
@@ -385,15 +396,15 @@ export default function CreateEventPage() {
           }
           let missingElements = [];
           for (let i = 0; i < row.length; i++) {
-            // index 9 is treated different because it is the only one that can be accepted as empty
-            if (i !== 9 && row[i] === '') {
+            // PUBLISH_DATE is treated different because it is the only one that can be accepted as empty
+            if (i !== CSV_COLUMN.PUBLISH_DATE && row[i] === '') {
               emptyValueCounter++;
               missingElements.push(i);
             }
           }
           if (emptyValueCounter > 0) {
             const missingColumnNames = missingElements.map((i) => headersArray[0][i]);
-            showFileErrorModal(`Missing required columns: ${missingColumnNames.join(', ')}`);
+            showFileErrorModal(`Missing required elements: ${missingColumnNames.join(', ')}`);
             return;
           }
         }
@@ -415,41 +426,32 @@ export default function CreateEventPage() {
     }
 
     for (const row of values) {
-      /* row layout
-        [0] - string - name
-        [1] - string - date
-        [2] - string - time
-        [3] - string - location
-        [4] - string - description
-        [5] - string - max attendees
-        [6] - string - waitlist
-        [7] - string - publish status
-        [8] - string - visibility
-        [9] - string - publish date
-       */
-
-      const waitlistValue = Number(row[6]);
+      const waitlistValue = Number(row[CSV_COLUMN.WAITLIST]);
       const hasWaitlist = !Number.isNaN(waitlistValue) && waitlistValue > 0;
+      const rowStatus = row[CSV_COLUMN.STATUS].toLowerCase();
+      const rowVisibility = row[CSV_COLUMN.VISIBILITY].toLowerCase();
 
       const payload = {
         id: crypto.randomUUID(),
-        name: row[0].trim(),
-        date: row[1],
-        time: row[2],
-        location: row[3].trim(),
-        description: row[4].trim(),
+        name: row[CSV_COLUMN.EVENT_NAME].trim(),
+        date: row[CSV_COLUMN.DATE],
+        time: row[CSV_COLUMN.TIME],
+        location: row[CSV_COLUMN.LOCATION].trim(),
+        description: row[CSV_COLUMN.DESCRIPTION].trim(),
         admins: allOrgAdminsCanEdit ? [] : eventAdminIds,
         all_org_admins_can_edit: allOrgAdminsCanEdit,
         registration_form: toApiRegistrationForm(questions),
         max_attendees:
-          Number(row[5]) === UNLIMITED_ATTENDEES ? UNLIMITED_ATTENDEES : Number(row[5]),
+          Number(row[CSV_COLUMN.MAX_ATTENDEES]) === UNLIMITED_ATTENDEES
+            ? UNLIMITED_ATTENDEES
+            : Number(row[CSV_COLUMN.MAX_ATTENDEES]),
         created_at: new Date().toISOString(),
-        status: row[7].toLowerCase(),
-        visibility: row[8].toLowerCase(),
-        minimum_visible_role: visibility === 'private' ? minimumVisibleRole : '',
+        status: rowStatus,
+        visibility: rowVisibility,
+        minimum_visible_role: rowVisibility === 'private' ? minimumVisibleRole : '',
         waitlist_enabled: hasWaitlist,
         waitlist_size: hasWaitlist ? waitlistValue : 0,
-        publish_date: toPublishDateValue(row[7].toLowerCase(), row[9]),
+        publish_date: toPublishDateValue(rowStatus, row[CSV_COLUMN.PUBLISH_DATE]),
       };
 
       setSubmitting(true);

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -90,8 +90,10 @@ export default function CreateEventPage() {
   const [submitting, setSubmitting] = useState(false);
   const [fileTable, setFileTable] = useState([]);
   const [fileData, setFileData] = useState([]);
-  const [columnArray, setColumnArray] = useState([]);
+  const [headersArray, setHeadersArray] = useState([]);
   const [values, setValues] = useState([]);
+  const [confirmModal, setConfirmModal] = useState(false);
+  const [modalWarningMessage, setModalWarningMessage] = useState('');
   const debounceRef = useRef(null);
   const isFileUpload = useRef(false);
 
@@ -298,6 +300,11 @@ export default function CreateEventPage() {
     );
   }
 
+  const EXPECTED_HEADERS = [
+    'Event Name', 'Date', 'Time', 'Location', 'Description',
+    'Max Attendees', 'Waitlist', 'Publish Status', 'Visibility', 'Publish Date',
+  ];
+
   function handleFileUpload(event) {
     const maxFileSize = 10 * 1024 * 1024;
     const file = event.target.files[0];
@@ -305,7 +312,8 @@ export default function CreateEventPage() {
     if (!file) return;
 
     if (file.size > maxFileSize) {
-      alert('File size exceeds the 10MB limit.');
+      setModalWarningMessage(`File size is ${file.size} and exceeds the 10MB limit.`);
+      setConfirmModal(true);
       event.target.value = '';
       return;
     }
@@ -314,15 +322,51 @@ export default function CreateEventPage() {
       header: true,
       skipEmptyLines: true,
       complete: function(result) {
-        const columnArray = [];
+        const headersArray = [];
         const valuesArray = [];
 
         result.data.map((data) => {
-          columnArray.push(Object.keys(data));
+          headersArray.push(Object.keys(data));
           valuesArray.push(Object.values(data));
         });
+
+        const required_number_of_columns = 10;
+
+        for (const row of valuesArray) {
+          let emptyValueCounter = 0;
+
+          if(row.length < required_number_of_columns) {
+            setFileData([]);
+            setHeadersArray([]);
+            setValues([]);
+            const actualHeaders = (headersArray[0] || []).map((h) => h.trim());
+            const missingHeaders = EXPECTED_HEADERS.filter((h) => !actualHeaders.includes(h));
+            setModalWarningMessage(`Missing required columns: ${missingHeaders.join(', ')}`);
+            setConfirmModal(true);
+            isFileUpload.current = false;
+            return;
+          }
+          let missingElements = [];
+          for (let i = 0; i < row.length; i++) {
+            if (i !== 9 && row[i] === '') {
+              emptyValueCounter++;
+              missingElements.push(i);
+            }
+          }
+          if (emptyValueCounter > 0) {
+            setFileData([]);
+            setHeadersArray([]);
+            setValues([]);
+            const missingColumnNames = missingElements.map((i) => headersArray[0][i]);
+            setModalWarningMessage(`Missing required elements: ${missingColumnNames.join(', ')}`);
+            setConfirmModal(true);
+            isFileUpload.current = true;
+            return;
+          }
+        }
+
         setFileData(result.data);
-        setColumnArray(columnArray[0]);
+        setHeadersArray(headersArray[0]);
         setValues(valuesArray);
       }
     });
@@ -331,7 +375,26 @@ export default function CreateEventPage() {
   }
 
   async function handleFileCreateEvent() {
+    if (values.length === 0) {
+      setModalWarningMessage('No valid rows to create. Please upload a valid CSV file.');
+      setConfirmModal(true);
+      return;
+    }
+
     for (const row of values) {
+      /* row layout
+        [0] - string - name
+        [1] - string - date
+        [2] - string - time
+        [3] - string - location
+        [4] - string - description
+        [5] - string - max attendees
+        [6] - string - waitlist
+        [7] - string - publish status
+        [8] - string - visibility
+        [9] - string - publish date
+       */
+
       const waitlistValue = Number(row[6]);
       const hasWaitlist = !Number.isNaN(waitlistValue) && waitlistValue > 0;
 
@@ -348,12 +411,12 @@ export default function CreateEventPage() {
         max_attendees:
           Number(row[5]) === UNLIMITED_ATTENDEES ? UNLIMITED_ATTENDEES : Number(row[5]),
         created_at: new Date().toISOString(),
-        status: row[7],
-        visibility: row[8],
+        status: row[7].toLowerCase(),
+        visibility: row[8].toLowerCase(),
         minimum_visible_role: visibility === 'private' ? minimumVisibleRole : '',
         waitlist_enabled: hasWaitlist,
         waitlist_size: hasWaitlist ? waitlistValue : 0,
-        publish_date: toPublishDateValue(row[7], row[9]),
+        publish_date: toPublishDateValue(row[7].toLowerCase(), row[9]),
       };
 
       setSubmitting(true);
@@ -367,11 +430,10 @@ export default function CreateEventPage() {
         }));
         return;
       }
-
-      history.push('/events');
-
-      isFileUpload.current = false;
     }
+    history.push('/events');
+
+    isFileUpload.current = false;
   }
 
   return (
@@ -413,6 +475,10 @@ export default function CreateEventPage() {
         setWaitlistSize,
         publishDate,
         setPublishDate,
+        confirmModal,
+        setConfirmModal,
+        modalWarningMessage,
+        setModalWarningMessage,
       }}
       questionActions={{
         questions,
@@ -448,7 +514,7 @@ export default function CreateEventPage() {
       fileActions={{
         handleFileUpload,
         fileData,
-        columnArray,
+        headersArray,
         values,
       }}
     />

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -305,6 +305,39 @@ export default function CreateEventPage() {
     'Max Attendees', 'Waitlist', 'Publish Status', 'Visibility', 'Publish Date',
   ];
 
+  const EXAMPLE_CSV_ROWS = [
+    EXPECTED_HEADERS,
+    ['Example Name', 'yyyy-mm-dd', 'hh:mm PM', 'Example Location', 'Example description', '20', '5', 'published', 'public', 'yyyy-mm-dd'],
+    ['Cookie party', '2026-08-21', '6:00 AM', 'Engineering Building', 'Eat cookies', '-1', '-1', 'draft', 'public', ''],
+    ['', '', '', '', '', '', '', '', '', ''],
+    ['Note: max attendees: -1 for unlimited, waitlist: -1 to disable, publish date: leave empty if none. Visibility can only be public atm. Do not touch row one and start at row two. DELETE THIS BOX BEFORE SUBMITTING', '', '', '', '', '', '', '', '', ''],
+  ];
+
+  /** Only quotes a cell when it actually needs it (contains a comma, quote, or newline). */
+  function toCsvCell(cell) {
+    const str = String(cell);
+    if (/[",\n]/.test(str)) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  }
+
+  const EXAMPLE_CSV = EXAMPLE_CSV_ROWS
+    .map((row) => row.map(toCsvCell).join(','))
+    .join('\r\n');
+
+  function handleDownloadExampleCsv() {
+    const blob = new Blob([EXAMPLE_CSV], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'example-events.csv';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
   function showFileErrorModal(modalMessage) {
     setFileData([]);
     setHeadersArray([]);
@@ -513,6 +546,7 @@ export default function CreateEventPage() {
       }}
       fileActions={{
         handleFileUpload,
+        handleDownloadExampleCsv,
         fileData,
         headersArray,
         values,

--- a/src/Pages/Events/CreateEventPage.js
+++ b/src/Pages/Events/CreateEventPage.js
@@ -8,6 +8,7 @@ import { membershipState } from '../../Enums';
 import { useEventQuestions, toApiRegistrationForm } from './useEventQuestions';
 import { getApiErrorMessage } from './eventUtils';
 import EventEditorForm from './EventEditorForm';
+import Papa from 'papaparse';
 
 /** Matches SCEvents `max_attendees` when there is no cap. */
 const UNLIMITED_ATTENDEES = -1;
@@ -87,7 +88,12 @@ export default function CreateEventPage() {
   const [adminSearching, setAdminSearching] = useState(false);
   const [submitError, setSubmitError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [fileTable, setFileTable] = useState([]);
+  const [fileData, setFileData] = useState([]);
+  const [columnArray, setColumnArray] = useState([]);
+  const [values, setValues] = useState([]);
   const debounceRef = useRef(null);
+  const isFileUpload = useRef(false);
 
   const isOfficerOrAdmin = user?.accessLevel >= membershipState.OFFICER;
 
@@ -292,6 +298,82 @@ export default function CreateEventPage() {
     );
   }
 
+  function handleFileUpload(event) {
+    const maxFileSize = 10 * 1024 * 1024;
+    const file = event.target.files[0];
+
+    if (!file) return;
+
+    if (file.size > maxFileSize) {
+      alert('File size exceeds the 10MB limit.');
+      event.target.value = '';
+      return;
+    }
+
+    Papa.parse(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: function(result) {
+        const columnArray = [];
+        const valuesArray = [];
+
+        result.data.map((data) => {
+          columnArray.push(Object.keys(data));
+          valuesArray.push(Object.values(data));
+        });
+        setFileData(result.data);
+        setColumnArray(columnArray[0]);
+        setValues(valuesArray);
+      }
+    });
+
+    isFileUpload.current = true;
+  }
+
+  async function handleFileCreateEvent() {
+    for (const row of values) {
+      const waitlistValue = Number(row[6]);
+      const hasWaitlist = !Number.isNaN(waitlistValue) && waitlistValue > 0;
+
+      const payload = {
+        id: crypto.randomUUID(),
+        name: row[0].trim(),
+        date: row[1],
+        time: row[2],
+        location: row[3].trim(),
+        description: row[4].trim(),
+        admins: allOrgAdminsCanEdit ? [] : eventAdminIds,
+        all_org_admins_can_edit: allOrgAdminsCanEdit,
+        registration_form: toApiRegistrationForm(questions),
+        max_attendees:
+          Number(row[5]) === UNLIMITED_ATTENDEES ? UNLIMITED_ATTENDEES : Number(row[5]),
+        created_at: new Date().toISOString(),
+        status: row[7],
+        visibility: row[8],
+        minimum_visible_role: visibility === 'private' ? minimumVisibleRole : '',
+        waitlist_enabled: hasWaitlist,
+        waitlist_size: hasWaitlist ? waitlistValue : 0,
+        publish_date: toPublishDateValue(row[7], row[9]),
+      };
+
+      setSubmitting(true);
+      const result = await createSCEvent(token, payload);
+      setSubmitting(false);
+
+      if (result.error) {
+        setSubmitError(getApiErrorMessage(result, {
+          fallback: 'SCEvents returned an error.',
+          networkHint: 'Is the SCEvents API running (e.g. Docker on port 8002)?',
+        }));
+        return;
+      }
+
+      history.push('/events');
+
+      isFileUpload.current = false;
+    }
+  }
+
   return (
     <EventEditorForm
       meta={{
@@ -300,7 +382,7 @@ export default function CreateEventPage() {
         containerClassName: 'mx-auto mt-3 mb-6 w-full max-w-4xl px-3 sm:mt-4 sm:mb-8 sm:px-6 md:mt-5 md:mb-10',
         submitLabel: 'Create event',
         submittingLabel: 'Creating…',
-        onSubmit: handleCreateEvent,
+        onSubmit: isFileUpload.current ? handleFileCreateEvent : handleCreateEvent,
         submitting,
         submitError,
         unlimitedAttendeesValue: UNLIMITED_ATTENDEES,
@@ -362,6 +444,12 @@ export default function CreateEventPage() {
             setEventAdmins([]);
           }
         },
+      }}
+      fileActions={{
+        handleFileUpload,
+        fileData,
+        columnArray,
+        values,
       }}
     />
   );

--- a/src/Pages/Events/EventEditorForm.js
+++ b/src/Pages/Events/EventEditorForm.js
@@ -1,6 +1,8 @@
 import { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import CreateEventFormQuestionBlock from './CreateEventFormQuestionBlock';
+import ConfirmationModal from
+  '../../Components/DecisionModal/ConfirmationModal.js';
 
 export default function EventEditorForm({
   meta,
@@ -50,12 +52,16 @@ export default function EventEditorForm({
     setWaitlistSize,
     publishDate,
     setPublishDate,
+    confirmModal,
+    setConfirmModal,
+    modalWarningMessage,
+    setModalWarningMessage,
   } = form;
 
   const {
     handleFileUpload,
     fileData = [],
-    columnArray = [],
+    headersArray = [],
     values = [],
   } = fileActions || {};
 
@@ -458,6 +464,22 @@ export default function EventEditorForm({
         </div>
       )}
 
+      <ConfirmationModal {... {
+        headerText: 'Warning',
+        bodyText: `Error: ${modalWarningMessage}`,
+        confirmText: 'Create',
+        cancelText: 'Close',
+        hideConfirmButton: true,
+        handleConfirmation: () => {
+          setConfirmModal(false);
+        },
+        handleCancel: () => {
+          setConfirmModal(false);
+        },
+        open: confirmModal,
+      }
+      }/>
+
       <div className="flex flex-wrap justify-start gap-3 border-t border-gray-200 pt-6 dark:border-gray-700">
         <button
           type="button"
@@ -487,7 +509,7 @@ export default function EventEditorForm({
       <table style={{borderCollapse: 'collapse', border: '1px solid black', margin: '5px auto'}}>
         <thead>
           <tr>
-            {columnArray.map((col, i) => (
+            {headersArray.map((col, i) => (
               <th style={{border: '1px solid blackg'}} key={i}>{col}</th>
             ))}
           </tr>

--- a/src/Pages/Events/EventEditorForm.js
+++ b/src/Pages/Events/EventEditorForm.js
@@ -7,6 +7,7 @@ export default function EventEditorForm({
   form,
   questionActions,
   adminActions,
+  fileActions,
 }) {
   const {
     title,
@@ -50,6 +51,13 @@ export default function EventEditorForm({
     publishDate,
     setPublishDate,
   } = form;
+
+  const {
+    handleFileUpload,
+    fileData = [],
+    columnArray = [],
+    values = [],
+  } = fileActions || {};
 
   const {
     questions,
@@ -459,10 +467,41 @@ export default function EventEditorForm({
         >
           {submitting ? submittingLabel : submitLabel}
         </button>
+        <label htmlFor="csv-file-input" className="btn btn-outline">
+          Import CSV
+        </label>
+        <input
+          type="file"
+          id="csv-file-input"
+          accept=".csv"
+          placeholder="Import CSV"
+          style={{ display: 'none' }}
+          onChange={handleFileUpload}
+        >
+        </input>
         <Link to="/events" className="btn btn-ghost">
           Cancel
         </Link>
       </div>
+
+      <table style={{borderCollapse: 'collapse', border: '1px solid black', margin: '5px auto'}}>
+        <thead>
+          <tr>
+            {columnArray.map((col, i) => (
+              <th style={{border: '1px solid blackg'}} key={i}>{col}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {values.map((v, i) => (
+            <tr key={i}>
+              {v.map((value, i) => (
+                <td style={{border: '1px solid blackg'}} key={i}>{value}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
 
       {eventDelete?.show && (
         <div className="mt-10 border-t border-gray-200 pt-8 dark:border-gray-700">

--- a/src/Pages/Events/EventEditorForm.js
+++ b/src/Pages/Events/EventEditorForm.js
@@ -54,8 +54,8 @@ export default function EventEditorForm({
     setPublishDate,
     confirmModal,
     setConfirmModal,
-    modalWarningMessage,
-    setModalWarningMessage,
+    modalErrorMessage,
+    setModalErrorMessage,
   } = form;
 
   const {
@@ -465,8 +465,8 @@ export default function EventEditorForm({
       )}
 
       <ConfirmationModal {... {
-        headerText: 'Warning',
-        bodyText: `Error: ${modalWarningMessage}`,
+        headerText: 'Error',
+        bodyText: modalErrorMessage,
         confirmText: 'Create',
         cancelText: 'Close',
         hideConfirmButton: true,

--- a/src/Pages/Events/EventEditorForm.js
+++ b/src/Pages/Events/EventEditorForm.js
@@ -60,6 +60,7 @@ export default function EventEditorForm({
 
   const {
     handleFileUpload,
+    handleDownloadExampleCsv,
     fileData = [],
     headersArray = [],
     values = [],
@@ -501,6 +502,13 @@ export default function EventEditorForm({
           onChange={handleFileUpload}
         >
         </input>
+        <button
+          type="button"
+          className="btn btn-outline"
+          onClick={handleDownloadExampleCsv}
+        >
+          Download Example CSV
+        </button>
         <Link to="/events" className="btn btn-ghost">
           Cancel
         </Link>

--- a/src/Pages/Events/eventUtils.js
+++ b/src/Pages/Events/eventUtils.js
@@ -56,4 +56,3 @@ export function getApiErrorMessage(result, options = {}) {
 
   return msg || fallback;
 }
-

--- a/src/Pages/Events/eventUtils.js
+++ b/src/Pages/Events/eventUtils.js
@@ -56,3 +56,4 @@ export function getApiErrorMessage(result, options = {}) {
 
   return msg || fallback;
 }
+


### PR DESCRIPTION
<img width="1435" height="295" alt="Screenshot 2026-08-12 225314" src="https://github.com/user-attachments/assets/f42d68e3-0e66-41fa-87ef-67f727a24312" />

https://github.com/user-attachments/assets/284f83bb-88db-4376-83c5-58402e40304e

Features: Adds import CSV option to create SCE events page. Displays table for data upon file upload. Click create events to publish all events in CSV file. Currently no support for adding registration questions or adding other event admins.

Image is example of a CSV file to create SCE events. Must include headers and each row is a single event. Date and time must be in the same format shown and publish status + visibility must be lowercase. To disable waitlist, put -1 as value. Publish date can be left empty if N/A.