### PR TITLE
Add bulk user editing for Clark admins

### DIFF
--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -29,6 +29,8 @@ const {sendUnsubscribeEmail} = require('../util/emailHelpers');
 const crypto = require('crypto');
 
 const ROWS_PER_PAGE = 20;
+const ALLOWED_ROWS_PER_PAGE = [10, 20, 50];
+const ALL_ROWS = 'all';
 
 const SENSITIVE_FIELDS = [
   'email',
@@ -220,15 +222,34 @@ router.post('/users', async function(req, res) {
   };
   const sortOrder = orderToInteger[req.query.order] || orderToInteger.default;
 
+  const total = await User.count(maybeOr);
+
+  // 'all' collapses every match onto a single page. anything we don't
+  // recognize falls back to the default rather than erroring, so callers that
+  // don't send a size keep working unchanged.
+  const requestedRowsPerPage = req.body.rowsPerPage;
+  const showAllRows = requestedRowsPerPage === ALL_ROWS;
+  let rowsPerPage = ROWS_PER_PAGE;
+  if (showAllRows) {
+    rowsPerPage = total;
+  } else if (ALLOWED_ROWS_PER_PAGE.includes(Number(requestedRowsPerPage))) {
+    rowsPerPage = Number(requestedRowsPerPage);
+  }
+
+  // mongo reads a limit of 0 as "no limit", which is what we want for 'all'
+  // and is also why we can't just pass rowsPerPage straight through
+  const limit = showAllRows ? 0 : rowsPerPage;
+
   // make sure that the page we want to see is 0 by default
   // and avoid negative page numbers
-  let skip = Math.max(Number(req.body.page) || 0, 0);
-  skip *= ROWS_PER_PAGE;
-  const total = await User.count(maybeOr);
-  User.find(maybeOr, { password: 0, }, { skip, limit: ROWS_PER_PAGE, })
+  const skip = showAllRows
+    ? 0
+    : Math.max(Number(req.body.page) || 0, 0) * rowsPerPage;
+
+  User.find(maybeOr, { password: 0, }, { skip, limit })
     .sort({ [sortColumn] : sortOrder })
     .then(items => {
-      res.status(OK).send({ items, total, rowsPerPage: ROWS_PER_PAGE, });
+      res.status(OK).send({ items, total, rowsPerPage, });
     })
     .catch((e) => {
       res.sendStatus(BAD_REQUEST);

--- a/api/main_endpoints/routes/User.js
+++ b/api/main_endpoints/routes/User.js
@@ -389,6 +389,115 @@ router.post('/edit', async (req, res) => {
   }
 });
 
+// Change the accessLevel of many members at once
+router.post('/bulkEdit', async (req, res) => {
+  const decoded = await decodeToken(req, membershipState.OFFICER);
+  if (decoded.status !== OK) {
+    return res.sendStatus(decoded.status);
+  }
+
+  const { accessLevel: editorAccessLevel, _id: editorId } = decoded.token;
+  const { ids, accessLevel } = req.body;
+  const isEditorAdmin = editorAccessLevel === membershipState.ADMIN;
+
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return res
+      .status(BAD_REQUEST)
+      .send({ message: 'ids must be a non-empty array.' });
+  }
+
+  const validAccessLevels = Object.values(membershipState);
+  if (!validAccessLevels.includes(accessLevel)) {
+    return res
+      .status(BAD_REQUEST)
+      .send({ message: `${accessLevel} is not a valid access level.` });
+  }
+
+  // Only admins can hand out the admin role
+  if (accessLevel === membershipState.ADMIN && !isEditorAdmin) {
+    return res.sendStatus(UNAUTHORIZED);
+  }
+
+  // Admins may re-role themselves, but an officer demoting themselves mid-bulk
+  // would lock them out of the page they're standing on
+  if (!isEditorAdmin && ids.some(id => String(id) === String(editorId))) {
+    return res
+      .status(FORBIDDEN)
+      .send({ message: 'Officers cannot change their own access level.' });
+  }
+
+  try {
+    const targetUsers = await User.find(
+      { _id: { $in: ids } },
+      '_id email accessLevel'
+    ).lean();
+
+    if (targetUsers.length === 0) {
+      return res.status(NOT_FOUND).send({ message: 'No users found.' });
+    }
+
+    // An officer can't touch anyone ranked above them. /delete draws the same
+    // line; bulk selection makes it much easier to sweep up an admin by
+    // accident, so we skip those rather than fail the whole request.
+    const editable = [];
+    const skipped = [];
+    targetUsers.forEach(targetUser => {
+      if (isEditorAdmin || targetUser.accessLevel <= editorAccessLevel) {
+        editable.push(targetUser);
+      } else {
+        skipped.push({ _id: targetUser._id, email: targetUser.email });
+      }
+    });
+
+    // Users already at the target level would otherwise produce audit log
+    // entries claiming a change that didn't happen
+    const changed = editable.filter(
+      targetUser => targetUser.accessLevel !== accessLevel
+    );
+
+    if (changed.length === 0) {
+      return res.status(OK).send({
+        message: 'No changes submitted.',
+        modified: 0,
+        skipped,
+      });
+    }
+
+    const result = await User.updateMany(
+      { _id: { $in: changed.map(targetUser => targetUser._id) } },
+      { accessLevel }
+    );
+
+    // one entry per user, shaped like the one /edit writes so the audit log
+    // page renders them the same way
+    changed.forEach(targetUser => {
+      const fieldChanges = {
+        accessLevel: { from: targetUser.accessLevel, to: accessLevel },
+      };
+      AuditLog.create({
+        userId: editorId,
+        action: AuditLogActions.UPDATE_USER,
+        documentId: targetUser._id,
+        details: {
+          updatedInfo: JSON.stringify({ accessLevel }),
+          fieldChanges: JSON.stringify(fieldChanges),
+        },
+      }).catch(logger.error);
+    });
+
+    return res.status(OK).send({
+      message: `${changed.length} user(s) were updated.`,
+      modified: result.nModified,
+      skipped,
+    });
+  } catch (error) {
+    logger.error('/bulkEdit had an error:', error);
+    return res
+      .status(BAD_REQUEST)
+      .send({ message: 'Bad Request: Unable to update users.' });
+  }
+});
+
 router.post('/getPagesPrintedCount', async (req, res) => {
   const decoded = await decodeToken(req);
   if (decoded.status !== OK) {

--- a/src/APIFunctions/User.js
+++ b/src/APIFunctions/User.js
@@ -4,6 +4,8 @@ import { BASE_API_URL, membershipState, userFilterType } from '../Enums';
 /**
  * Queries the database for all users.
  * @param {string} token The jwt token for verification
+ * @param {(number|'all'|null)} rowsPerPage How many users to return per page.
+ * Accepts 10, 20, 50, or 'all'; anything else falls back to the server default.
  * @returns {UserApiResponse} Containing any error information or the array of
  * users.
  */
@@ -14,6 +16,7 @@ export async function getAllUsers({
   sortColumn = null,
   sortOrder = null,
   minRole = null,
+  rowsPerPage = null,
 }) {
   const url = new URL('/api/User/users', BASE_API_URL);
 
@@ -37,6 +40,7 @@ export async function getAllUsers({
         query,
         page,
         minRole,
+        rowsPerPage,
       }),
     });
     if (res.ok) {

--- a/src/APIFunctions/User.js
+++ b/src/APIFunctions/User.js
@@ -173,6 +173,38 @@ export async function editUser(userToEdit, token) {
 }
 
 /**
+ * Change the access level of many users in one request.
+ * @param {string[]} ids The MongoDB ids of the users to update
+ * @param {number} accessLevel The membershipState value to apply to all of them
+ * @param {string} token The jwt token for authentication
+ * @returns {UserApiResponse} containing the number modified and any users that
+ * were skipped because the editor outranked them
+ */
+export async function bulkEditUsers(ids, accessLevel, token) {
+  let status = new UserApiResponse();
+  const url = new URL('/api/User/bulkEdit', BASE_API_URL);
+  try {
+    const res = await fetch(url.href, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ ids, accessLevel }),
+    });
+    if (res.ok) {
+      status.responseData = await res.json();
+    } else {
+      status.error = true;
+    }
+  } catch (err) {
+    status.error = true;
+    status.responseData = err.message || err;
+  }
+  return status;
+}
+
+/**
  * Deletes a user by an ID
  * @param {string} _id The ID of the user to delete
  * @param {string} token jwt token to authorize deletion

--- a/src/Components/DecisionModal/ConfirmationModal.js
+++ b/src/Components/DecisionModal/ConfirmationModal.js
@@ -5,14 +5,17 @@ export default function ConfirmationModal(props) {
 
   const confirmText = props.confirmText || 'Confirm';
   const cancelText = props.cancelText || 'Cancel';
+  // pages rendering more than one modal must pass distinct ids, otherwise
+  // getElementById below finds whichever one mounted first
+  const id = props.id || 'confirmation-modal';
 
   useEffect(() => {
     if (open) {
-      document.getElementById('confirmation-modal').showModal();
+      document.getElementById(id).showModal();
     }
   }, [open]);
   return (<>
-    <dialog id="confirmation-modal" className="modal modal-bottom sm:modal-middle">
+    <dialog id={id} className="modal modal-bottom sm:modal-middle">
       <div className="modal-box">
         <h3 className="font-bold text-lg">{headerText}</h3>
         <p className="text-sm text-gray-500">

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 const svg = require('./SVG');
-import { getAllUsers, deleteUserByID, getNewPaidMembersThisSemester } from '../../APIFunctions/User';
+import { getAllUsers, deleteUserByID, getNewPaidMembersThisSemester, bulkEditUsers } from '../../APIFunctions/User';
 import { formatFirstAndLastName } from '../../APIFunctions/Profile';
 import { getAllUsersValidVerifiedAndSubscribed } from '../../APIFunctions/User';
 // import { membershipState } from '../../Enums';
@@ -9,14 +9,18 @@ import ConfirmationModal from
   '../../Components/DecisionModal/ConfirmationModal.js';
 const enums = require('../../Enums.js');
 import { useSCE } from '../../Components/context/SceContext.js';
+import SelectDropdown from './SelectDropdown.js';
 
 const ALL_ROWS = 'all';
 const DEFAULT_PAGE_SIZE = 20;
-const PAGE_SIZE_OPTIONS = [10, DEFAULT_PAGE_SIZE, 50, ALL_ROWS];
-
-function pageSizeLabel(pageSize) {
-  return pageSize === ALL_ROWS ? 'All' : String(pageSize);
-}
+const PAGE_SIZE_OPTIONS = [10, DEFAULT_PAGE_SIZE, 50, ALL_ROWS].map(value => ({
+  value,
+  label: value === ALL_ROWS ? 'All' : String(value),
+}));
+const ROLE_OPTIONS = Object.values(enums.membershipState).map(value => ({
+  value,
+  label: enums.membershipStateToString(value),
+}));
 
 export default function Overview() {
   const { user } = useSCE();
@@ -33,7 +37,11 @@ export default function Overview() {
   // what the user picked in the dropdown. distinct from rowsPerPage, which is
   // the size the server actually used -- under 'all' those two differ.
   const [pageSizeChoice, setPageSizeChoice] = useState(DEFAULT_PAGE_SIZE);
-  const [isPageSizeDropdownOpen, setIsPageSizeDropdownOpen] = useState(false);
+  const [selectedIds, setSelectedIds] = useState(new Set());
+  const [bulkAccessLevel, setBulkAccessLevel] = useState(
+    enums.membershipState.MEMBER
+  );
+  const [toggleBulkEdit, setToggleBulkEdit] = useState(false);
   const [currentSortColumn, setCurrentSortColumn] = useState('joinDate');
   const [currentSortOrder, setCurrentSortOrder] = useState('desc');
   const [clubRevenueData, setClubRevenueData] = useState({newMembersThisYear:0, newSingleSemesterMembers:0, newAnnualMembers:0, currentActiveMembers:0});
@@ -66,6 +74,13 @@ export default function Overview() {
         child => !child._id.includes(userToDel._id)
       )
     );
+    // the row is gone, so leaving it selected would let a bulk edit target a
+    // user who is no longer on screen
+    setSelectedIds(previouslySelected => {
+      const nextSelected = new Set(previouslySelected);
+      nextSelected.delete(userToDel._id);
+      return nextSelected;
+    });
   }
 
   function mark(bool) {
@@ -89,6 +104,9 @@ export default function Overview() {
       setTotal(apiResponse.responseData.total);
       setRowsPerPage(apiResponse.responseData.rowsPerPage);
     }
+    // every refetch replaces the rendered rows, so any prior selection refers
+    // to users that are no longer on screen
+    setSelectedIds(new Set());
     setLoading(false);
   }
 
@@ -142,9 +160,48 @@ export default function Overview() {
 
   function handlePageSizeChange(pageSize) {
     setPageSizeChoice(pageSize);
-    setIsPageSizeDropdownOpen(false);
     // whatever page we were on probably doesn't exist at the new size
     setPage(0);
+  }
+
+  function toggleUserSelection(userId) {
+    setSelectedIds(previouslySelected => {
+      const nextSelected = new Set(previouslySelected);
+      if (nextSelected.has(userId)) {
+        nextSelected.delete(userId);
+      } else {
+        nextSelected.add(userId);
+      }
+      return nextSelected;
+    });
+  }
+
+  function toggleSelectAll() {
+    setSelectedIds(previouslySelected =>
+      previouslySelected.size === users.length
+        ? new Set()
+        : new Set(users.map(userOnPage => userOnPage._id))
+    );
+  }
+
+  async function bulkUpdateAccessLevel() {
+    const response = await bulkEditUsers(
+      [...selectedIds],
+      bulkAccessLevel,
+      user.token
+    );
+    if (response.error) {
+      return alert('unable to update the selected users, check logs');
+    }
+    const skipped = response.responseData.skipped || [];
+    if (skipped.length) {
+      alert(
+        `${skipped.length} user(s) were skipped because they outrank you: ` +
+        skipped.map(skippedUser => skippedUser.email).join(', ')
+      );
+    }
+    // refetch so the table shows the new roles. this also clears the selection
+    callDatabase();
   }
 
   function handleArrowVisibility(sortOrder, columnName) {
@@ -235,6 +292,7 @@ export default function Overview() {
   return (
     <div className='overview-container bg-white dark:bg-gradient-to-r dark:from-gray-800 dark:to-gray-600 min-h-[100dvh]'>
       <ConfirmationModal {... {
+        id: 'delete-user-modal',
         headerText: `Delete ${userToDelete.firstName} ${userToDelete.lastName} ?`,
         bodyText: `Are you sure you want to delete 
           ${userToDelete.firstName}? They'll be gone forever if you do.`,
@@ -247,6 +305,22 @@ export default function Overview() {
         },
         handleCancel: () => setToggleDelete(!toggleDelete),
         open: toggleDelete
+      }
+      } />
+      <ConfirmationModal {... {
+        id: 'bulk-edit-modal',
+        headerText: `Change ${selectedIds.size} user(s) to ` +
+          `${enums.membershipStateToString(bulkAccessLevel)}?`,
+        bodyText: 'This updates every selected user at once. Users who ' +
+          'outrank you will be skipped.',
+        confirmText: 'Yes, update them',
+        cancelText: 'Never mind',
+        handleConfirmation: () => {
+          bulkUpdateAccessLevel();
+          setToggleBulkEdit(!toggleBulkEdit);
+        },
+        handleCancel: () => setToggleBulkEdit(!toggleBulkEdit),
+        open: toggleBulkEdit
       }
       } />
       <div className='px-4'>
@@ -301,45 +375,70 @@ export default function Overview() {
               />
             </label>
             <div className='relative w-full sm:w-48 sm:shrink-0'>
-              <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
-                Entries per page
-              </label>
-              <button
-                onClick={() => setIsPageSizeDropdownOpen(!isPageSizeDropdownOpen)}
+              <SelectDropdown
+                label='Entries per page'
+                options={PAGE_SIZE_OPTIONS}
+                value={pageSizeChoice}
+                onChange={handlePageSizeChange}
                 disabled={loading}
-                className='w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md text-gray-900 dark:text-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 flex justify-between items-center'
-              >
-                <span>{pageSizeLabel(pageSizeChoice)}</span>
-                <svg
-                  className={`w-4 h-4 transition-transform ${isPageSizeDropdownOpen ? 'rotate-180' : ''}`}
-                  fill='none'
-                  stroke='currentColor'
-                  viewBox='0 0 24 24'
-                >
-                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M19 9l-7 7-7-7' />
-                </svg>
-              </button>
-
-              {isPageSizeDropdownOpen && (
-                <div className='absolute z-10 w-full mt-1 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg max-h-60 overflow-y-auto'>
-                  <div className='p-2'>
-                    {PAGE_SIZE_OPTIONS.map(option => (
-                      <button
-                        key={option}
-                        onClick={() => handlePageSizeChange(option)}
-                        className={`w-full text-left text-sm p-2 rounded cursor-pointer text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-600 ${option === pageSizeChoice ? 'bg-gray-100 dark:bg-gray-600' : ''}`}
-                      >
-                        {pageSizeLabel(option)}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
+              />
             </div>
           </div>
+          {selectedIds.size > 0 && (
+            <div className='flex flex-col gap-4 mb-6 p-4 bg-gray-100 dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-700 sm:flex-row sm:items-end'>
+              <span className='text-sm font-medium text-gray-700 dark:text-gray-300 sm:flex-1'>
+                {selectedIds.size} selected
+              </span>
+              <div className='relative w-full sm:w-48 sm:shrink-0'>
+                <SelectDropdown
+                  label='Set membership status to'
+                  options={ROLE_OPTIONS}
+                  value={bulkAccessLevel}
+                  onChange={setBulkAccessLevel}
+                />
+              </div>
+              <div className='flex gap-2'>
+                <button
+                  onClick={() => setToggleBulkEdit(!toggleBulkEdit)}
+                  className='px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500'
+                >
+                  Apply
+                </button>
+                <button
+                  onClick={() => setSelectedIds(new Set())}
+                  className='px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500'
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+          )}
           <table className='table px-3'>
             <thead>
               <tr>
+                <th className='w-px'>
+                  <div className='flex items-center justify-center'>
+                    <input
+                      type='checkbox'
+                      className='form-checkbox h-4 w-4 text-blue-600 bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500'
+                      aria-label='Select every user on this page'
+                      disabled={users.length === 0}
+                      checked={
+                        users.length > 0 && selectedIds.size === users.length
+                      }
+                      // indeterminate is a DOM property, not an attribute, so
+                      // react can't set it declaratively
+                      ref={checkbox => {
+                        if (checkbox) {
+                          checkbox.indeterminate =
+                            selectedIds.size > 0 &&
+                            selectedIds.size < users.length;
+                        }
+                      }}
+                      onChange={toggleSelectAll}
+                    />
+                  </div>
+                </th>
                 {[
                   { title: 'Name/Email', className: 'text-base text-gray-700 dark:text-white/70', columnName: 'email'},
                   { title: 'Printing', className: 'text-base text-gray-700 dark:text-white/70 hidden text-center md:table-cell', columnName: 'pagesPrinted'},
@@ -367,6 +466,17 @@ export default function Overview() {
             <tbody>
               {users.map((user) => (
                 <tr className='break-all !rounded md:break-keep hover:bg-gray-100 dark:hover:bg-white/10' key={user.email}>
+                  <td className='w-px'>
+                    <div className='flex items-center justify-center'>
+                      <input
+                        type='checkbox'
+                        className='form-checkbox h-4 w-4 text-blue-600 bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500'
+                        aria-label={`Select ${user.email}`}
+                        checked={selectedIds.has(user._id)}
+                        onChange={() => toggleUserSelection(user._id)}
+                      />
+                    </div>
+                  </td>
                   <td className=''>
                     <a className='link link-hover text-blue-600 dark:text-blue-400' target="_blank" rel="noopener noreferrer" href={`/user/edit/${user._id}`}>
                       {formatFirstAndLastName(user)}

--- a/src/Pages/Overview/Overview.js
+++ b/src/Pages/Overview/Overview.js
@@ -10,6 +10,14 @@ import ConfirmationModal from
 const enums = require('../../Enums.js');
 import { useSCE } from '../../Components/context/SceContext.js';
 
+const ALL_ROWS = 'all';
+const DEFAULT_PAGE_SIZE = 20;
+const PAGE_SIZE_OPTIONS = [10, DEFAULT_PAGE_SIZE, 50, ALL_ROWS];
+
+function pageSizeLabel(pageSize) {
+  return pageSize === ALL_ROWS ? 'All' : String(pageSize);
+}
+
 export default function Overview() {
   const { user } = useSCE();
   const [toggleDelete, setToggleDelete] = useState(false);
@@ -22,6 +30,10 @@ export default function Overview() {
   const [queryResult, setQueryResult] = useState([]);
   const [rowsPerPage, setRowsPerPage] = useState(0);
   const [query, setQuery] = useState('');
+  // what the user picked in the dropdown. distinct from rowsPerPage, which is
+  // the size the server actually used -- under 'all' those two differ.
+  const [pageSizeChoice, setPageSizeChoice] = useState(DEFAULT_PAGE_SIZE);
+  const [isPageSizeDropdownOpen, setIsPageSizeDropdownOpen] = useState(false);
   const [currentSortColumn, setCurrentSortColumn] = useState('joinDate');
   const [currentSortOrder, setCurrentSortOrder] = useState('desc');
   const [clubRevenueData, setClubRevenueData] = useState({newMembersThisYear:0, newSingleSemesterMembers:0, newAnnualMembers:0, currentActiveMembers:0});
@@ -69,7 +81,8 @@ export default function Overview() {
       query: query,
       page: page,
       sortColumn: sortColumn,
-      sortOrder: sortOrder
+      sortOrder: sortOrder,
+      rowsPerPage: pageSizeChoice
     });
     if (!apiResponse.error) {
       setUsers(apiResponse.responseData.items);
@@ -89,7 +102,7 @@ export default function Overview() {
   useEffect(() => {
     callDatabase();
     getClubRevenueData();
-  }, [page, currentSortColumn, currentSortOrder]);
+  }, [page, currentSortColumn, currentSortOrder, pageSizeChoice]);
 
   useEffect(() => {
 
@@ -125,6 +138,13 @@ export default function Overview() {
       setCurrentSortColumn(columnName);
       setCurrentSortOrder('asc');
     }
+  }
+
+  function handlePageSizeChange(pageSize) {
+    setPageSizeChoice(pageSize);
+    setIsPageSizeDropdownOpen(false);
+    // whatever page we were on probably doesn't exist at the new size
+    setPage(0);
   }
 
   function handleArrowVisibility(sortOrder, columnName) {
@@ -252,8 +272,8 @@ export default function Overview() {
           <p className='mb-2'>Current Active Members: {clubRevenueData.currentActiveMembers}</p>
         </div>
         <div className='px-6 border rounded-lg border-gray-300 dark:border-white/10'>
-          <div className='py-6'>
-            <label className="w-full form-control">
+          <div className='flex flex-col gap-4 py-6 sm:flex-row sm:items-end'>
+            <label className="w-full form-control sm:flex-1">
               <div className="label">
                 <span className="label-text text-md text-gray-700 dark:text-white">Type a search, followed by the enter key</span>
               </div>
@@ -280,6 +300,42 @@ export default function Overview() {
                 }}
               />
             </label>
+            <div className='relative w-full sm:w-48 sm:shrink-0'>
+              <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
+                Entries per page
+              </label>
+              <button
+                onClick={() => setIsPageSizeDropdownOpen(!isPageSizeDropdownOpen)}
+                disabled={loading}
+                className='w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md text-gray-900 dark:text-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 flex justify-between items-center'
+              >
+                <span>{pageSizeLabel(pageSizeChoice)}</span>
+                <svg
+                  className={`w-4 h-4 transition-transform ${isPageSizeDropdownOpen ? 'rotate-180' : ''}`}
+                  fill='none'
+                  stroke='currentColor'
+                  viewBox='0 0 24 24'
+                >
+                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M19 9l-7 7-7-7' />
+                </svg>
+              </button>
+
+              {isPageSizeDropdownOpen && (
+                <div className='absolute z-10 w-full mt-1 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg max-h-60 overflow-y-auto'>
+                  <div className='p-2'>
+                    {PAGE_SIZE_OPTIONS.map(option => (
+                      <button
+                        key={option}
+                        onClick={() => handlePageSizeChange(option)}
+                        className={`w-full text-left text-sm p-2 rounded cursor-pointer text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-600 ${option === pageSizeChoice ? 'bg-gray-100 dark:bg-gray-600' : ''}`}
+                      >
+                        {pageSizeLabel(option)}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
           <table className='table px-3'>
             <thead>

--- a/src/Pages/Overview/SelectDropdown.js
+++ b/src/Pages/Overview/SelectDropdown.js
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+
+/**
+ * Single-select dropdown styled to match the activity filter on the Audit Log
+ * page. Closes once an option is picked.
+ *
+ * The options panel is absolutely positioned, so the caller is responsible for
+ * placing this inside an element with `relative` and a width.
+ *
+ * @param {string} label Rendered above the trigger button. Optional.
+ * @param {{value: *, label: string}[]} options
+ * @param {*} value The currently selected option's value
+ * @param {function} onChange Called with the newly selected option's value
+ * @param {boolean} disabled
+ */
+export default function SelectDropdown({
+  label,
+  options,
+  value,
+  onChange,
+  disabled = false,
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedOption = options.find(option => option.value === value);
+
+  return (
+    <>
+      {label && (
+        <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
+          {label}
+        </label>
+      )}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        disabled={disabled}
+        className='w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md text-gray-900 dark:text-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 flex justify-between items-center'
+      >
+        <span>{selectedOption ? selectedOption.label : ''}</span>
+        <svg
+          className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          fill='none'
+          stroke='currentColor'
+          viewBox='0 0 24 24'
+        >
+          <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M19 9l-7 7-7-7' />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className='absolute z-10 w-full mt-1 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg max-h-60 overflow-y-auto'>
+          <div className='p-2'>
+            {options.map(option => (
+              <button
+                key={option.value}
+                onClick={() => {
+                  onChange(option.value);
+                  setIsOpen(false);
+                }}
+                className={`w-full text-left text-sm p-2 rounded cursor-pointer text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-600 ${option.value === value ? 'bg-gray-100 dark:bg-gray-600' : ''}`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/test/api/User.js
+++ b/test/api/User.js
@@ -953,4 +953,334 @@ describe('User', () => {
       });
     });
   });
+
+  describe('/POST bulkEdit', () => {
+    let member;
+    let officer;
+    let admin;
+
+    const editorOfficer = {
+      _id: new mongoose.Types.ObjectId().toString(),
+      accessLevel: MEMBERSHIP_STATE.OFFICER,
+    };
+    const editorAdmin = {
+      _id: new mongoose.Types.ObjectId().toString(),
+      accessLevel: MEMBERSHIP_STATE.ADMIN,
+    };
+
+    beforeEach(async () => {
+      await User.deleteMany({});
+      await AuditLog.deleteMany({});
+      member = await new User({
+        email: 'bulk-member@sce.dev',
+        password: 'Passw0rd',
+        firstName: 'Mem',
+        lastName: 'Ber',
+        major: 'Computer Science',
+        accessLevel: MEMBERSHIP_STATE.MEMBER,
+      }).save();
+      officer = await new User({
+        email: 'bulk-officer@sce.dev',
+        password: 'Passw0rd',
+        firstName: 'Off',
+        lastName: 'Icer',
+        major: 'Computer Science',
+        accessLevel: MEMBERSHIP_STATE.OFFICER,
+      }).save();
+      admin = await new User({
+        email: 'bulk-admin@sce.dev',
+        password: 'Passw0rd',
+        firstName: 'Ad',
+        lastName: 'Min',
+        major: 'Computer Science',
+        accessLevel: MEMBERSHIP_STATE.ADMIN,
+      }).save();
+    });
+
+    after(async () => {
+      await User.deleteMany({});
+      await AuditLog.deleteMany({});
+    });
+
+    it('Should return statusCode 401 if no token is passed in', async () => {
+      const result = await test.sendPostRequest('/api/User/bulkEdit', {
+        ids: [member._id.toString()],
+        accessLevel: MEMBERSHIP_STATE.OFFICER,
+      });
+      expect(result).to.have.status(UNAUTHORIZED);
+    });
+
+    it('Should return statusCode 403 if an invalid token was passed in',
+      async () => {
+        setTokenStatus(null);
+        const result = await test.sendPostRequestWithToken(
+          token, '/api/User/bulkEdit', {
+            ids: [member._id.toString()],
+            accessLevel: MEMBERSHIP_STATE.OFFICER,
+          });
+        expect(result).to.have.status(FORBIDDEN);
+      });
+
+    it('Should return statusCode 400 if ids is not a non-empty array',
+      async () => {
+        setTokenStatus(true, editorOfficer);
+        for (const ids of [undefined, [], 'not-an-array', {}]) {
+          const result = await test.sendPostRequestWithToken(
+            token, '/api/User/bulkEdit', {
+              ids,
+              accessLevel: MEMBERSHIP_STATE.MEMBER,
+            });
+          expect(result).to.have.status(BAD_REQUEST);
+        }
+      });
+
+    it('Should return statusCode 400 for an invalid access level',
+      async () => {
+        setTokenStatus(true, editorOfficer);
+        for (const accessLevel of [99, -7, 'OFFICER', undefined]) {
+          const result = await test.sendPostRequestWithToken(
+            token, '/api/User/bulkEdit', {
+              ids: [member._id.toString()],
+              accessLevel,
+            });
+          expect(result).to.have.status(BAD_REQUEST);
+        }
+      });
+
+    it('Should return statusCode 401 if an officer tries to grant admin',
+      async () => {
+        setTokenStatus(true, editorOfficer);
+        const result = await test.sendPostRequestWithToken(
+          token, '/api/User/bulkEdit', {
+            ids: [member._id.toString()],
+            accessLevel: MEMBERSHIP_STATE.ADMIN,
+          });
+        expect(result).to.have.status(UNAUTHORIZED);
+      });
+
+    it('Should let an admin grant admin', async () => {
+      setTokenStatus(true, editorAdmin);
+      const result = await test.sendPostRequestWithToken(
+        token, '/api/User/bulkEdit', {
+          ids: [member._id.toString()],
+          accessLevel: MEMBERSHIP_STATE.ADMIN,
+        });
+      expect(result).to.have.status(OK);
+      const updated = await User.findById(member._id).lean();
+      expect(updated.accessLevel).to.equal(MEMBERSHIP_STATE.ADMIN);
+    });
+
+    it('Should return statusCode 403 if an officer includes themselves',
+      async () => {
+        setTokenStatus(true, {
+          _id: officer._id.toString(),
+          accessLevel: MEMBERSHIP_STATE.OFFICER,
+        });
+        const result = await test.sendPostRequestWithToken(
+          token, '/api/User/bulkEdit', {
+            ids: [member._id.toString(), officer._id.toString()],
+            accessLevel: MEMBERSHIP_STATE.MEMBER,
+          });
+        expect(result).to.have.status(FORBIDDEN);
+        // the whole request is rejected, so the other user is untouched
+        const untouched = await User.findById(member._id).lean();
+        expect(untouched.accessLevel).to.equal(MEMBERSHIP_STATE.MEMBER);
+      });
+
+    it('Should let an admin include themselves', async () => {
+      setTokenStatus(true, {
+        _id: admin._id.toString(),
+        accessLevel: MEMBERSHIP_STATE.ADMIN,
+      });
+      const result = await test.sendPostRequestWithToken(
+        token, '/api/User/bulkEdit', {
+          ids: [admin._id.toString()],
+          accessLevel: MEMBERSHIP_STATE.MEMBER,
+        });
+      expect(result).to.have.status(OK);
+      const updated = await User.findById(admin._id).lean();
+      expect(updated.accessLevel).to.equal(MEMBERSHIP_STATE.MEMBER);
+    });
+
+    it('Should update every selected user', async () => {
+      setTokenStatus(true, editorAdmin);
+      const result = await test.sendPostRequestWithToken(
+        token, '/api/User/bulkEdit', {
+          ids: [member._id.toString(), officer._id.toString()],
+          accessLevel: MEMBERSHIP_STATE.PENDING,
+        });
+      expect(result).to.have.status(OK);
+      expect(result.body.modified).to.equal(2);
+      const updated = await User.find({
+        _id: { $in: [member._id, officer._id] }
+      }).lean();
+      updated.forEach(updatedUser => {
+        expect(updatedUser.accessLevel).to.equal(MEMBERSHIP_STATE.PENDING);
+      });
+    });
+
+    it('Should skip users who outrank the editor', async () => {
+      setTokenStatus(true, editorOfficer);
+      const result = await test.sendPostRequestWithToken(
+        token, '/api/User/bulkEdit', {
+          ids: [member._id.toString(), admin._id.toString()],
+          accessLevel: MEMBERSHIP_STATE.NON_MEMBER,
+        });
+      expect(result).to.have.status(OK);
+      expect(result.body.skipped).to.have.length(1);
+      expect(result.body.skipped[0].email).to.equal('bulk-admin@sce.dev');
+      const untouchedAdmin = await User.findById(admin._id).lean();
+      expect(untouchedAdmin.accessLevel).to.equal(MEMBERSHIP_STATE.ADMIN);
+      const updatedMember = await User.findById(member._id).lean();
+      expect(updatedMember.accessLevel).to.equal(MEMBERSHIP_STATE.NON_MEMBER);
+    });
+
+    it('Should not report changes for users already at the target level',
+      async () => {
+        setTokenStatus(true, editorAdmin);
+        const result = await test.sendPostRequestWithToken(
+          token, '/api/User/bulkEdit', {
+            ids: [officer._id.toString()],
+            accessLevel: MEMBERSHIP_STATE.OFFICER,
+          });
+        expect(result).to.have.status(OK);
+        expect(result.body.modified).to.equal(0);
+        const auditEntries = await AuditLog.find({}).lean();
+        expect(auditEntries).to.have.length(0);
+      });
+
+    it('Should return statusCode 404 if none of the ids exist', async () => {
+      setTokenStatus(true, editorAdmin);
+      const result = await test.sendPostRequestWithToken(
+        token, '/api/User/bulkEdit', {
+          ids: [new mongoose.Types.ObjectId().toString()],
+          accessLevel: MEMBERSHIP_STATE.MEMBER,
+        });
+      expect(result).to.have.status(NOT_FOUND);
+    });
+
+    it('Should write one audit log per changed user', async () => {
+      setTokenStatus(true, editorAdmin);
+      const result = await test.sendPostRequestWithToken(
+        token, '/api/User/bulkEdit', {
+          ids: [member._id.toString(), officer._id.toString()],
+          accessLevel: MEMBERSHIP_STATE.NON_MEMBER,
+        });
+      expect(result).to.have.status(OK);
+
+      const auditEntries = await AuditLog.find({
+        action: AuditLogActions.UPDATE_USER
+      }).lean();
+      expect(auditEntries).to.have.length(2);
+
+      const memberEntry = auditEntries.find(
+        entry => String(entry.documentId) === member._id.toString()
+      );
+      expect(memberEntry).to.exist;
+      const fieldChanges = JSON.parse(memberEntry.details.fieldChanges);
+      expect(fieldChanges.accessLevel).to.deep.equal({
+        from: MEMBERSHIP_STATE.MEMBER,
+        to: MEMBERSHIP_STATE.NON_MEMBER
+      });
+    });
+  });
+
+  describe('/POST users rowsPerPage', () => {
+    const SEEDED_USERS = 25;
+    const DEFAULT_ROWS_PER_PAGE = 20;
+
+    before(async () => {
+      await User.deleteMany({});
+      await User.insertMany(
+        Array.from({ length: SEEDED_USERS }, (_, index) => ({
+          email: `rows-per-page-${index}@sce.com`,
+          password: 'Passw0rd',
+          firstName: `first-${index}`,
+          lastName: `last-${index}`,
+          major: 'Computer Science',
+        }))
+      );
+    });
+
+    beforeEach(() => {
+      setTokenStatus(true);
+    });
+
+    after(async () => {
+      await User.deleteMany({});
+    });
+
+    it('Should default to 20 rows per page when rowsPerPage is omitted',
+      async () => {
+        const result = await test.sendPostRequestWithToken(
+          token, '/api/User/users', {});
+        expect(result).to.have.status(OK);
+        expect(result.body.rowsPerPage).to.equal(DEFAULT_ROWS_PER_PAGE);
+        expect(result.body.items.length).to.equal(DEFAULT_ROWS_PER_PAGE);
+        expect(result.body.total).to.equal(SEEDED_USERS);
+      });
+
+    it('Should return only the requested number of rows', async () => {
+      const result = await test.sendPostRequestWithToken(
+        token, '/api/User/users', { rowsPerPage: 10 });
+      expect(result).to.have.status(OK);
+      expect(result.body.rowsPerPage).to.equal(10);
+      expect(result.body.items.length).to.equal(10);
+      expect(result.body.total).to.equal(SEEDED_USERS);
+    });
+
+    it('Should return every user when fewer exist than the requested size',
+      async () => {
+        const result = await test.sendPostRequestWithToken(
+          token, '/api/User/users', { rowsPerPage: 50 });
+        expect(result).to.have.status(OK);
+        expect(result.body.rowsPerPage).to.equal(50);
+        expect(result.body.items.length).to.equal(SEEDED_USERS);
+      });
+
+    it('Should offset by the requested size when paging', async () => {
+      const firstPage = await test.sendPostRequestWithToken(
+        token, '/api/User/users', { rowsPerPage: 10, page: 0 });
+      const thirdPage = await test.sendPostRequestWithToken(
+        token, '/api/User/users', { rowsPerPage: 10, page: 2 });
+      expect(thirdPage).to.have.status(OK);
+      // 25 users at 10 per page leaves 5 on the final page
+      expect(thirdPage.body.items.length).to.equal(5);
+      const firstPageIds = firstPage.body.items.map(user => String(user._id));
+      thirdPage.body.items.forEach(user => {
+        expect(firstPageIds).to.not.include(String(user._id));
+      });
+    });
+
+    it('Should return every matching user when rowsPerPage is "all"',
+      async () => {
+        const result = await test.sendPostRequestWithToken(
+          token, '/api/User/users', { rowsPerPage: 'all' });
+        expect(result).to.have.status(OK);
+        expect(result.body.items.length).to.equal(SEEDED_USERS);
+        expect(result.body.rowsPerPage).to.equal(SEEDED_USERS);
+      });
+
+    it('Should respect the query when rowsPerPage is "all"', async () => {
+      const result = await test.sendPostRequestWithToken(
+        token, '/api/User/users', { rowsPerPage: 'all', query: 'first-1' });
+      expect(result).to.have.status(OK);
+      // first-1, and first-10 through first-19
+      expect(result.body.items.length).to.equal(11);
+      expect(result.body.total).to.equal(11);
+      expect(result.body.rowsPerPage).to.equal(11);
+    });
+
+    it('Should fall back to 20 rows per page for a disallowed size',
+      async () => {
+        const disallowedSizes = [1000, 0, -5, 'everything', null];
+        for (const rowsPerPage of disallowedSizes) {
+          const result = await test.sendPostRequestWithToken(
+            token, '/api/User/users', { rowsPerPage });
+          expect(result).to.have.status(OK);
+          expect(result.body.rowsPerPage).to.equal(DEFAULT_ROWS_PER_PAGE);
+          expect(result.body.items.length).to.equal(DEFAULT_ROWS_PER_PAGE);
+        }
+      });
+  });
 });


### PR DESCRIPTION
## Motivation
Every semester, officers change. The default behavior of officer accounts on Clark is that they never expire, so every semester their accounts must be updated by the president. This is a one-by-one editing process. 

## Implementation
This PR accomplishes two tasks:

- [ ] **Adding customizable pagination to the user manager**. This allows the admin to see 10, 20, 50, or all users. 
- [ ] **Bulk user edits**. The admin can now select multiple users and update all of their membership statuses. This action is gated behind the confirmation modal to avoid mistakes in updates. This was implemented via a new `/bulkEdit` endpoint that is more efficient than repeatedly calling `/edit`. 

## Testing
Unit tests were added to verify the modified functionality of user profiles.