### PR TITLE
Remove door codes for expired memberships

### DIFF
--- a/api/main_endpoints/routes/Auth.js
+++ b/api/main_endpoints/routes/Auth.js
@@ -24,7 +24,12 @@ const {
 const membershipState = require('../../util/constants').MEMBERSHIP_STATE;
 const PASSWORD_RESET_EXPIRATION = require('../../util/constants').PASSWORD_RESET_EXPIRATION;
 const { sendVerificationEmail, sendPasswordReset } = require('../util/emailHelpers');
-const { userWithEmailExists, checkIfPageCountResets, findPasswordReset } = require('../util/userHelpers');
+const {
+  userWithEmailExists,
+  checkIfPageCountResets,
+  findPasswordReset,
+  expireMembershipIfLapsed
+} = require('../util/userHelpers');
 
 const AuditLogActions = require('../util/auditLogActions.js');
 const AuditLog = require('../models/AuditLog.js');
@@ -170,12 +175,20 @@ router.post('/login', async (req, res) => {
       return res.status(UNAUTHORIZED).send({ message: `Account ${email} is banned lol` });
     }
 
+    // Nothing else expires memberships, so catch a lapsed one here and strip
+    // the door code before it can be handed back out on the profile page
+    const membershipLapsed = expireMembershipIfLapsed(user);
+
     // Handle Page Reset
     if (checkIfPageCountResets(user.lastLogin)) {
       user.pagesPrinted = 0;
     }
     user.lastLogin = new Date();
     await user.save();
+
+    if (membershipLapsed) {
+      logger.info('Membership lapsed, revoked door code for user:', String(user._id));
+    }
 
     const token = jwt.sign({
       _id: user._id,

--- a/api/main_endpoints/util/userHelpers.js
+++ b/api/main_endpoints/util/userHelpers.js
@@ -228,9 +228,35 @@ async function updateMembershipDetails(userId, numberOfSemestersToSignUpFor, doo
   }
 }
 
+/**
+ * Revoke a member's benefits once their membership has lapsed. Officers and
+ * above aren't subject to membership expiration, so they keep their door code.
+ * Mutates the document in place; the caller is responsible for saving it.
+ * @param {Object} user - The user document to check
+ * @returns {Boolean} whether the membership had lapsed
+ */
+function expireMembershipIfLapsed(user) {
+  if (!user || user.accessLevel !== membershipState.MEMBER) {
+    return false;
+  }
+  if (!user.membershipValidUntil) {
+    return false;
+  }
+  // `$gt` is how getNewPaidMembersThisSemester counts active members, so an
+  // expiration landing exactly on now counts as lapsed here too
+  if (new Date(user.membershipValidUntil) > new Date()) {
+    return false;
+  }
+
+  user.accessLevel = membershipState.NON_MEMBER;
+  user.doorCode = undefined;
+  return true;
+}
+
 module.exports = {
   registerUser,
   getMemberExpirationDate,
+  expireMembershipIfLapsed,
   testPasswordStrength,
   hashPassword,
   userWithEmailExists,


### PR DESCRIPTION
## Motivation
When SCE memberships expire, those members are no longer entitled to a door code. Furthermore, door codes are reset by the department every academic year. Clark never addressed these issues, and memberships that expired were still tied to a door code months, and even years, after expiry.

## The Fix
Every time a user logs into Clark, there is a check to see when their membership expires. If it's already expired, the door code is removed from their profile and their status is set back to `NON_MEMBER`. This is the correctly expected behavior of an expired membership, and fixes any potential scenarios where previous members have access to door codes that may or may not work on the room door. 