### PR TITLE
Enhance calendar with Day, Week, and Year view mode

### DIFF
--- a/src/Pages/Events/Calendar/CalendarHeader.js
+++ b/src/Pages/Events/Calendar/CalendarHeader.js
@@ -1,17 +1,17 @@
 import { Link } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, PlusIcon } from '../EventIcons';
-import { MONTHS, YEAR_RANGE } from './calendarConstants';
+import { ChevronDown, ChevronLeft, ChevronRight, PlusIcon } from '../EventIcons';
+import { VIEW_MODES } from './calendarConstants';
 
 export function CalendarHeader({
-  month,
-  year,
-  monthEventCount,
+  view,
+  onViewChange,
+  title,
+  eventCount,
+  countLabel,
   canCreateEvent,
-  onMonthChange,
-  onYearChange,
   onTodayClick,
-  onPreviousMonth,
-  onNextMonth,
+  onPrevious,
+  onNext,
 }) {
   return (
     <div className="flex flex-wrap items-start justify-between gap-3 px-5 py-4 border-b border-slate-600/50">
@@ -19,32 +19,20 @@ export function CalendarHeader({
         <div className="flex flex-wrap items-center gap-3">
           <div className="relative w-28 sm:w-36">
             <select
-              value={month}
-              onChange={onMonthChange}
-              aria-label="Select month"
+              value={view}
+              onChange={(e) => onViewChange(e.target.value)}
+              aria-label="Select calendar view"
               className="h-10 w-full appearance-none rounded-lg border border-slate-400/40 bg-slate-800 px-4 pr-10 text-[14px] font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
             >
-              {MONTHS.map((monthName, index) => (
-                <option key={monthName} value={index} className="bg-slate-900">
-                  {monthName}
+              {VIEW_MODES.map(({ label, value }) => (
+                <option key={value} value={value} className="bg-slate-900">
+                  {label}
                 </option>
               ))}
             </select>
-          </div>
-
-          <div className="relative w-24">
-            <select
-              value={year}
-              onChange={onYearChange}
-              aria-label="Select year"
-              className="h-10 w-full appearance-none rounded-lg border border-slate-400/40 bg-slate-800 px-4 pr-10 text-[14px] font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-cyan-400"
-            >
-              {YEAR_RANGE.map((yearOption) => (
-                <option key={yearOption} value={yearOption} className="bg-slate-900">
-                  {yearOption}
-                </option>
-              ))}
-            </select>
+            <div className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-slate-300">
+              <ChevronDown />
+            </div>
           </div>
 
           <button
@@ -56,11 +44,11 @@ export function CalendarHeader({
         </div>
 
         <p className="text-sm font-medium tracking-wide text-slate-300">
-          {monthEventCount} event{monthEventCount !== 1 ? 's' : ''} this month
+          {eventCount} event{eventCount !== 1 ? 's' : ''} {countLabel}
         </p>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-[6px]">
         {canCreateEvent && (
           <Link
             to="/events/create"
@@ -71,8 +59,12 @@ export function CalendarHeader({
           </Link>
         )}
 
+        <span className="mr-[6px] text-[14px] font-semibold text-slate-100 whitespace-nowrap">
+          {title}
+        </span>
+
         <button
-          onClick={onPreviousMonth}
+          onClick={onPrevious}
           aria-label="Previous month"
           className="flex items-center justify-center w-10 h-10 transition border rounded-lg border-slate-400/40 bg-slate-800 text-slate-100 hover:border-slate-300 hover:bg-slate-700 hover:text-white"
         >
@@ -80,7 +72,7 @@ export function CalendarHeader({
         </button>
 
         <button
-          onClick={onNextMonth}
+          onClick={onNext}
           aria-label="Next month"
           className="flex items-center justify-center w-10 h-10 transition border rounded-lg border-slate-400/40 bg-slate-800 text-slate-100 hover:border-slate-300 hover:bg-slate-700 hover:text-white"
         >

--- a/src/Pages/Events/Calendar/CalendarHeader.js
+++ b/src/Pages/Events/Calendar/CalendarHeader.js
@@ -65,7 +65,7 @@ export function CalendarHeader({
 
         <button
           onClick={onPrevious}
-          aria-label="Previous month"
+          aria-label={`Previous ${view}`}
           className="flex items-center justify-center w-10 h-10 transition border rounded-lg border-slate-400/40 bg-slate-800 text-slate-100 hover:border-slate-300 hover:bg-slate-700 hover:text-white"
         >
           <ChevronLeft />
@@ -73,7 +73,7 @@ export function CalendarHeader({
 
         <button
           onClick={onNext}
-          aria-label="Next month"
+          aria-label={`Next ${view}`}
           className="flex items-center justify-center w-10 h-10 transition border rounded-lg border-slate-400/40 bg-slate-800 text-slate-100 hover:border-slate-300 hover:bg-slate-700 hover:text-white"
         >
           <ChevronRight />

--- a/src/Pages/Events/Calendar/CalendarView.js
+++ b/src/Pages/Events/Calendar/CalendarView.js
@@ -1,12 +1,18 @@
 import { useState, useMemo } from 'react';
 import { toDateKey } from '../eventUtils';
-import { eventDateKey, sortEventsForDay } from './calendarUtils';
+import {
+  countLabel,
+  eventDateKey,
+  sortEventsForDay,
+  stepCursor,
+  viewTitle,
+  visibleRange,
+} from './calendarUtils';
 import { EventPopup } from './EventPopup';
 import { CalendarHeader } from './CalendarHeader';
 import { CalendarGrid } from './CalendarGrid';
 import { MobileMonthAgenda } from './MobileMonthAgenda';
 import { CalendarLegend } from './CalendarLegend';
-import { MONTHS } from './calendarConstants';
 
 export default function CalendarView({
   events,
@@ -56,9 +62,10 @@ export default function CalendarView({
     };
   });
 
-  const monthEventCount = cells
-    .filter((c) => c.isCurrentMonth)
-    .reduce((sum, c) => sum + c.events.length, 0);
+  const { startDate, endDate } = visibleRange(view, cursor);
+  const eventCount = Object.entries(eventsByDate).reduce((sum, [key, dayEvents]) => {
+    return key >= startDate && key <= endDate ? sum + dayEvents.length : sum;
+  }, 0);
 
   const monthEvents = useMemo(() => {
     return cells
@@ -86,13 +93,16 @@ export default function CalendarView({
         <CalendarHeader
           view={view}
           onViewChange={onViewChange}
-          title={`${MONTHS[month]} ${year}`}
-          eventCount={monthEventCount}
-          countLabel="this month"
+          title={viewTitle(view, cursor)}
+          eventCount={eventCount}
+          countLabel={countLabel(view)}
           canCreateEvent={canCreateEvent}
-          onTodayClick={() => setCursor(new Date(today.getFullYear(), today.getMonth(), 1))}
-          onPrevious={() => setCursor(new Date(year, month - 1, 1))}
-          onNext={() => setCursor(new Date(year, month + 1, 1))}
+          onTodayClick={() => {
+            const day = view === 'day' || view === 'week' ? today.getDate() : 1;
+            setCursor(new Date(today.getFullYear(), today.getMonth(), day));
+          }}
+          onPrevious={() => setCursor(stepCursor(view, cursor, -1))}
+          onNext={() => setCursor(stepCursor(view, cursor, 1))}
         />
 
         <div className="flex-1 min-h-0 overflow-y-auto sm:hidden">

--- a/src/Pages/Events/Calendar/CalendarView.js
+++ b/src/Pages/Events/Calendar/CalendarView.js
@@ -14,6 +14,7 @@ import { CalendarGrid } from './CalendarGrid';
 import { MobileMonthAgenda } from './MobileMonthAgenda';
 import { CalendarLegend } from './CalendarLegend';
 import { TimeGrid } from './TimeGrid';
+import { YearView } from './YearView';
 
 export default function CalendarView({
   events,
@@ -24,6 +25,7 @@ export default function CalendarView({
   setCursor,
   view,
   onViewChange,
+  onYearMonthSelect,
 }) {
   const today = useMemo(() => new Date(), []);
   const [selectedEvent, setSelectedEvent] = useState(null);
@@ -129,6 +131,15 @@ export default function CalendarView({
           <TimeGrid
             days={view === 'day' ? dayViewDays : weekViewDays}
             onSelectEvent={setSelectedEvent}
+            isAdminView={isAdminView}
+          />
+        ) : view === 'year' ? (
+          <YearView
+            year={year}
+            activeMonth={month}
+            eventsByDate={eventsByDate}
+            onSelectEvent={setSelectedEvent}
+            onSelectMonth={onYearMonthSelect}
             isAdminView={isAdminView}
           />
         ) : (

--- a/src/Pages/Events/Calendar/CalendarView.js
+++ b/src/Pages/Events/Calendar/CalendarView.js
@@ -13,6 +13,7 @@ import { CalendarHeader } from './CalendarHeader';
 import { CalendarGrid } from './CalendarGrid';
 import { MobileMonthAgenda } from './MobileMonthAgenda';
 import { CalendarLegend } from './CalendarLegend';
+import { TimeGrid } from './TimeGrid';
 
 export default function CalendarView({
   events,
@@ -66,6 +67,13 @@ export default function CalendarView({
   const eventCount = Object.entries(eventsByDate).reduce((sum, [key, dayEvents]) => {
     return key >= startDate && key <= endDate ? sum + dayEvents.length : sum;
   }, 0);
+  const cursorKey = toDateKey(cursor);
+  const dayViewDays = [{
+    date: cursor,
+    key: cursorKey,
+    isToday: cursorKey === todayKey,
+    events: eventsByDate[cursorKey] || [],
+  }];
 
   const monthEvents = useMemo(() => {
     return cells
@@ -89,7 +97,9 @@ export default function CalendarView({
         />
       )}
 
-      <div className="flex h-full max-h-full flex-col overflow-hidden rounded-xl border border-slate-500/50 bg-slate-800/85 shadow-[0_0_0_1px_rgba(148,163,184,0.05)] sm:h-auto sm:max-h-none">
+      <div className={view === 'month'
+        ? 'flex h-full max-h-full flex-col overflow-hidden rounded-xl border border-slate-500/50 bg-slate-800/85 shadow-[0_0_0_1px_rgba(148,163,184,0.05)] sm:h-auto sm:max-h-none'
+        : 'flex h-full max-h-full flex-col overflow-hidden rounded-xl border border-slate-500/50 bg-slate-800/85 shadow-[0_0_0_1px_rgba(148,163,184,0.05)]'}>
         <CalendarHeader
           view={view}
           onViewChange={onViewChange}
@@ -105,19 +115,29 @@ export default function CalendarView({
           onNext={() => setCursor(stepCursor(view, cursor, 1))}
         />
 
-        <div className="flex-1 min-h-0 overflow-y-auto sm:hidden">
-          <MobileMonthAgenda
-            monthEvents={monthEvents}
+        {view === 'day' ? (
+          <TimeGrid
+            days={dayViewDays}
             onSelectEvent={setSelectedEvent}
             isAdminView={isAdminView}
           />
-        </div>
+        ) : (
+          <>
+            <div className="flex-1 min-h-0 overflow-y-auto sm:hidden">
+              <MobileMonthAgenda
+                monthEvents={monthEvents}
+                onSelectEvent={setSelectedEvent}
+                isAdminView={isAdminView}
+              />
+            </div>
 
-        <CalendarGrid
-          cells={cells}
-          onSelectEvent={setSelectedEvent}
-          isAdminView={isAdminView}
-        />
+            <CalendarGrid
+              cells={cells}
+              onSelectEvent={setSelectedEvent}
+              isAdminView={isAdminView}
+            />
+          </>
+        )}
 
         <CalendarLegend isAdminView={isAdminView} />
       </div>

--- a/src/Pages/Events/Calendar/CalendarView.js
+++ b/src/Pages/Events/Calendar/CalendarView.js
@@ -74,6 +74,16 @@ export default function CalendarView({
     isToday: cursorKey === todayKey,
     events: eventsByDate[cursorKey] || [],
   }];
+  const weekViewDays = Array.from({ length: 7 }, (_, dayOffset) => {
+    const date = new Date(year, month, cursor.getDate() - cursor.getDay() + dayOffset);
+    const key = toDateKey(date);
+    return {
+      date,
+      key,
+      isToday: key === todayKey,
+      events: eventsByDate[key] || [],
+    };
+  });
 
   const monthEvents = useMemo(() => {
     return cells
@@ -115,9 +125,9 @@ export default function CalendarView({
           onNext={() => setCursor(stepCursor(view, cursor, 1))}
         />
 
-        {view === 'day' ? (
+        {view === 'day' || view === 'week' ? (
           <TimeGrid
-            days={dayViewDays}
+            days={view === 'day' ? dayViewDays : weekViewDays}
             onSelectEvent={setSelectedEvent}
             isAdminView={isAdminView}
           />

--- a/src/Pages/Events/Calendar/CalendarView.js
+++ b/src/Pages/Events/Calendar/CalendarView.js
@@ -6,6 +6,7 @@ import { CalendarHeader } from './CalendarHeader';
 import { CalendarGrid } from './CalendarGrid';
 import { MobileMonthAgenda } from './MobileMonthAgenda';
 import { CalendarLegend } from './CalendarLegend';
+import { MONTHS } from './calendarConstants';
 
 export default function CalendarView({
   events,
@@ -14,6 +15,8 @@ export default function CalendarView({
   canCreateEvent = false,
   cursor,
   setCursor,
+  view,
+  onViewChange,
 }) {
   const today = useMemo(() => new Date(), []);
   const [selectedEvent, setSelectedEvent] = useState(null);
@@ -34,16 +37,6 @@ export default function CalendarView({
 
   const year = cursor.getFullYear();
   const month = cursor.getMonth();
-
-  function handleMonthChange(e) {
-    const nextMonth = Number(e.target.value);
-    setCursor(new Date(year, nextMonth, 1));
-  }
-
-  function handleYearChange(e) {
-    const nextYear = Number(e.target.value);
-    setCursor(new Date(nextYear, month, 1));
-  }
 
   const firstDayOfMonth = new Date(year, month, 1).getDay();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -91,15 +84,15 @@ export default function CalendarView({
 
       <div className="flex h-full max-h-full flex-col overflow-hidden rounded-xl border border-slate-500/50 bg-slate-800/85 shadow-[0_0_0_1px_rgba(148,163,184,0.05)] sm:h-auto sm:max-h-none">
         <CalendarHeader
-          month={month}
-          year={year}
-          monthEventCount={monthEventCount}
+          view={view}
+          onViewChange={onViewChange}
+          title={`${MONTHS[month]} ${year}`}
+          eventCount={monthEventCount}
+          countLabel="this month"
           canCreateEvent={canCreateEvent}
-          onMonthChange={handleMonthChange}
-          onYearChange={handleYearChange}
           onTodayClick={() => setCursor(new Date(today.getFullYear(), today.getMonth(), 1))}
-          onPreviousMonth={() => setCursor(new Date(year, month - 1, 1))}
-          onNextMonth={() => setCursor(new Date(year, month + 1, 1))}
+          onPrevious={() => setCursor(new Date(year, month - 1, 1))}
+          onNext={() => setCursor(new Date(year, month + 1, 1))}
         />
 
         <div className="flex-1 min-h-0 overflow-y-auto sm:hidden">

--- a/src/Pages/Events/Calendar/TimeGrid.js
+++ b/src/Pages/Events/Calendar/TimeGrid.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { bucketEventsByHour, formatTime } from './calendarUtils';
+import { DAYS } from './calendarConstants';
 import { EventRow } from './EventRow';
 
 const START_HOUR = 8;
@@ -7,14 +8,104 @@ const START_HOUR = 8;
 export function TimeGrid({ days, onSelectEvent, isAdminView }) {
   const scrollContainerRef = useRef(null);
   const startHourRef = useRef(null);
+  const isWeekView = days.length === 7;
   const day = days[0] || { key: '', isToday: false, events: [] };
-  const { allDayEvents, eventsByHour } = bucketEventsByHour(day.events);
+  const dayBuckets = days.map(({ events }) => bucketEventsByHour(events));
+  const { allDayEvents, eventsByHour } = dayBuckets[0];
 
   useEffect(() => {
     if (scrollContainerRef.current && startHourRef.current) {
       scrollContainerRef.current.scrollTop = startHourRef.current.offsetTop;
     }
   }, [day.key]);
+
+  if (isWeekView) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col overflow-x-auto">
+        <div className="flex min-h-0 min-w-[640px] flex-1 flex-col">
+          <div className="grid shrink-0 grid-cols-[5rem_repeat(7,minmax(0,1fr))] border-b border-slate-700/70 bg-slate-900/35">
+            <div />
+            {days.map((weekDay, index) => (
+              <div
+                key={weekDay.key}
+                className="flex flex-col items-center gap-1 py-2 text-center text-[10px] font-bold uppercase tracking-[0.22em] text-slate-400"
+              >
+                <span>{DAYS[index]}</span>
+                <span
+                  className={[
+                    'flex h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-xs font-semibold tracking-normal',
+                    weekDay.isToday ? 'bg-cyan-400 text-slate-950' : 'text-slate-200',
+                  ].join(' ')}
+                >
+                  {weekDay.date.getDate()}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid shrink-0 grid-cols-[5rem_repeat(7,minmax(0,1fr))] border-b border-slate-700/60 bg-slate-900/20 [&>*:nth-child(8n)]:border-r-0">
+            <div className="whitespace-nowrap border-r border-slate-700/60 px-2 py-3 text-right text-[10px] font-semibold text-slate-400">
+              All day
+            </div>
+            {days.map((weekDay, index) => (
+              <div
+                key={weekDay.key}
+                className={[
+                  'min-w-0 space-y-1 border-r border-slate-700/60 p-1.5',
+                  weekDay.isToday ? 'bg-cyan-500/[0.12]' : '',
+                ].join(' ')}
+              >
+                {dayBuckets[index].allDayEvents.map((event, eventIndex) => (
+                  <EventRow
+                    key={event.id || event._id || `${weekDay.key}-all-day-${eventIndex}`}
+                    event={{ ...event, time: '' }}
+                    onSelect={() => onSelectEvent(event)}
+                    isAdminView={isAdminView}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+
+          <div
+            ref={scrollContainerRef}
+            aria-label="Hourly schedule"
+            className="relative flex-1 min-h-0 overflow-y-auto overscroll-contain"
+          >
+            {Array.from({ length: 24 }, (_, hour) => (
+              <div
+                key={hour}
+                ref={hour === START_HOUR ? startHourRef : null}
+                className="grid min-h-[8.333333%] grid-cols-[5rem_repeat(7,minmax(0,1fr))] border-b border-slate-700/60 [&>*:nth-child(8n)]:border-r-0"
+              >
+                <div className="whitespace-nowrap border-r border-slate-700/60 px-2 pt-1 text-right text-[10px] font-semibold text-slate-400">
+                  {formatTime(`${String(hour).padStart(2, '0')}:00`)}
+                </div>
+                {days.map((weekDay, index) => (
+                  <div
+                    key={weekDay.key}
+                    className={[
+                      'flex min-w-0 flex-col gap-1 border-r border-slate-700/60 p-1',
+                      weekDay.isToday ? 'bg-cyan-500/[0.12]' : '',
+                    ].join(' ')}
+                  >
+                    {dayBuckets[index].eventsByHour[hour].map((event, eventIndex) => (
+                      <EventRow
+                        key={event.id || event._id || `${weekDay.key}-${hour}-${eventIndex}`}
+                        event={event}
+                        onSelect={onSelectEvent}
+                        isAdminView={isAdminView}
+                      />
+                    ))}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/src/Pages/Events/Calendar/TimeGrid.js
+++ b/src/Pages/Events/Calendar/TimeGrid.js
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+import { bucketEventsByHour, formatTime } from './calendarUtils';
+import { EventRow } from './EventRow';
+
+const START_HOUR = 8;
+
+export function TimeGrid({ days, onSelectEvent, isAdminView }) {
+  const scrollContainerRef = useRef(null);
+  const startHourRef = useRef(null);
+  const day = days[0] || { key: '', isToday: false, events: [] };
+  const { allDayEvents, eventsByHour } = bucketEventsByHour(day.events);
+
+  useEffect(() => {
+    if (scrollContainerRef.current && startHourRef.current) {
+      scrollContainerRef.current.scrollTop = startHourRef.current.offsetTop;
+    }
+  }, [day.key]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="grid shrink-0 grid-cols-[5rem_minmax(0,1fr)] border-b border-slate-700/60 bg-slate-900/20">
+        <div className="whitespace-nowrap border-r border-slate-700/60 px-2 py-3 text-right text-[10px] font-semibold text-slate-400">
+          All day
+        </div>
+        <div className="min-w-0 space-y-1 p-1.5">
+          {allDayEvents.map((event, index) => (
+            <EventRow
+              key={event.id || event._id || `${day.key}-all-day-${index}`}
+              event={{ ...event, time: '' }}
+              onSelect={() => onSelectEvent(event)}
+              isAdminView={isAdminView}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div
+        ref={scrollContainerRef}
+        aria-label="Hourly schedule"
+        className="relative flex-1 min-h-0 overflow-y-auto overscroll-contain"
+      >
+        {eventsByHour.map((hourEvents, hour) => (
+          <div
+            key={hour}
+            ref={hour === START_HOUR ? startHourRef : null}
+            className="grid min-h-[8.333333%] grid-cols-[5rem_minmax(0,1fr)] border-b border-slate-700/60"
+          >
+            <div className="whitespace-nowrap border-r border-slate-700/60 px-2 pt-1 text-right text-[10px] font-semibold text-slate-400">
+              {formatTime(`${String(hour).padStart(2, '0')}:00`)}
+            </div>
+            <div className="flex min-w-0 flex-col gap-1 p-1">
+              {hourEvents.map((event, index) => (
+                <EventRow
+                  key={event.id || event._id || `${day.key}-${hour}-${index}`}
+                  event={event}
+                  onSelect={onSelectEvent}
+                  isAdminView={isAdminView}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/Pages/Events/Calendar/YearView.js
+++ b/src/Pages/Events/Calendar/YearView.js
@@ -130,7 +130,8 @@ export function YearView({
                             ? 'bg-slate-700/70 text-slate-50'
                             : 'text-slate-200 hover:bg-slate-700/60',
                       ].join(' ')}
-                      aria-label={`${monthName} ${date.getDate()}, ${year}`}
+                      aria-label={`${monthName} ${date.getDate()}, ${year}, ${eventsByDate[dateKey]?.length || 0} event${eventsByDate[dateKey]?.length === 1 ? '' : 's'}`}
+                      aria-pressed={isSelected}
                     >
                       <span
                         className={[

--- a/src/Pages/Events/Calendar/YearView.js
+++ b/src/Pages/Events/Calendar/YearView.js
@@ -60,6 +60,7 @@ export function YearView({
             </div>
 
             {selectedEvents.length > 0 ? (
+              <div className="mt-2 max-h-28 space-y-1 overflow-y-auto">
                 {selectedEvents.map((event, index) => (
                   <EventRow
                     key={event.id || event._id || `${selectedDateKey}-${index}`}

--- a/src/Pages/Events/Calendar/YearView.js
+++ b/src/Pages/Events/Calendar/YearView.js
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react';
+import { toDateKey } from '../eventUtils';
+import { DAYS, MONTHS } from './calendarConstants';
+import { miniMonthMatrix } from './calendarUtils';
+import { EventRow } from './EventRow';
+
+export function YearView({
+  year,
+  activeMonth,
+  eventsByDate,
+  onSelectEvent,
+  onSelectMonth,
+  isAdminView,
+}) {
+  const todayKey = toDateKey(new Date());
+  const [selectedDate, setSelectedDate] = useState(null);
+  const monthRefs = useRef([]);
+  const selectedDateKey = selectedDate ? toDateKey(selectedDate) : null;
+  const selectedEvents = selectedDateKey ? eventsByDate[selectedDateKey] || [] : [];
+
+  useEffect(() => {
+    setSelectedDate(null);
+  }, [year]);
+
+  useEffect(() => {
+    monthRefs.current[activeMonth]?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  }, [activeMonth, year]);
+
+  function handleYearContentClick(event) {
+    if (
+      event.target.closest('button')
+      || event.target.closest('[data-year-date-preview]')
+    ) return;
+    setSelectedDate(null);
+  }
+
+  return (
+    <div className="flex-1 min-h-0 overflow-y-auto" onClick={handleYearContentClick}>
+      {selectedDate && (
+        <div
+          className="sticky top-0 z-10 w-full px-4 pt-3 sm:px-5"
+          data-year-date-preview="true"
+        >
+          <div className="rounded-lg border border-slate-700/60 bg-slate-900/95 p-3 shadow-lg">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm font-semibold text-slate-100">
+                {MONTHS[selectedDate.getMonth()]} {selectedDate.getDate()}, {year}
+              </p>
+              <button
+                type="button"
+                onClick={() => setSelectedDate(null)}
+                className="rounded px-2 py-1 text-xs font-semibold text-slate-300 transition hover:bg-slate-700 hover:text-white"
+                aria-label="Clear selected date"
+              >
+                Close
+              </button>
+            </div>
+
+            {selectedEvents.length > 0 ? (
+              <div className="mt-2 max-h-28 space-y-1 overflow-y-auto">
+                {selectedEvents.map((event) => (
+                  <EventRow
+                    key={event.id}
+                    event={event}
+                    onSelect={onSelectEvent}
+                    isAdminView={isAdminView}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="mt-2 text-xs text-slate-400">No events scheduled for this date.</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div
+        className="grid w-full grid-cols-1 gap-y-3 p-4 sm:grid-cols-3 sm:gap-x-4 sm:gap-y-4 sm:p-5"
+        data-admin-view={isAdminView ? 'true' : 'false'}
+      >
+        {MONTHS.map((monthName, monthIndex) => {
+          const monthDates = miniMonthMatrix(year, monthIndex);
+
+          return (
+            <section
+              key={monthName}
+              ref={(node) => {
+                monthRefs.current[monthIndex] = node;
+              }}
+              className="min-w-0 rounded-lg border border-slate-700/50 bg-slate-900/20 p-2"
+            >
+              <button
+                type="button"
+                onClick={() => onSelectMonth(monthIndex)}
+                className="mb-2 w-full text-center text-sm font-semibold text-slate-100 transition hover:text-cyan-200"
+              >
+                {monthName}
+              </button>
+
+              <div className="grid grid-cols-7 text-center text-[9px] font-bold uppercase tracking-[0.1em] text-slate-500">
+                {DAYS.map((day) => (
+                  <span key={day}>{day}</span>
+                ))}
+              </div>
+
+              <div className="grid grid-cols-7 gap-y-0.5">
+                {monthDates.map((date, index) => {
+                  if (!date) {
+                    return <div key={`${monthName}-${index}`} className="h-9" aria-hidden="true" />;
+                  }
+
+                  const dateKey = toDateKey(date);
+                  const isToday = dateKey === todayKey;
+                  const isSelected = dateKey === selectedDateKey;
+                  const hasEvents = Boolean(eventsByDate[dateKey]?.length);
+
+                  return (
+                    <button
+                      key={dateKey}
+                      type="button"
+                      onClick={() => setSelectedDate(date)}
+                      className={[
+                        'flex h-9 flex-col items-center justify-center gap-1 rounded-md text-xs transition-colors',
+                        isToday
+                          ? 'text-slate-950'
+                          : isSelected
+                            ? 'bg-slate-700/70 text-slate-50'
+                            : 'text-slate-200 hover:bg-slate-700/60',
+                      ].join(' ')}
+                      aria-label={`${monthName} ${date.getDate()}`}
+                    >
+                      <span
+                        className={[
+                          'flex h-5 w-5 items-center justify-center rounded-full leading-none',
+                          isToday ? 'bg-cyan-400 text-slate-950' : '',
+                        ].join(' ')}
+                      >
+                        {date.getDate()}
+                      </span>
+                      <span
+                        className={[
+                          'h-1 w-1 rounded-full',
+                          hasEvents ? 'bg-cyan-300' : 'invisible',
+                        ].join(' ')}
+                      />
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/Pages/Events/Calendar/YearView.js
+++ b/src/Pages/Events/Calendar/YearView.js
@@ -130,7 +130,7 @@ export function YearView({
                             ? 'bg-slate-700/70 text-slate-50'
                             : 'text-slate-200 hover:bg-slate-700/60',
                       ].join(' ')}
-                      aria-label={`${monthName} ${date.getDate()}`}
+                      aria-label={`${monthName} ${date.getDate()}, ${year}`}
                     >
                       <span
                         className={[

--- a/src/Pages/Events/Calendar/YearView.js
+++ b/src/Pages/Events/Calendar/YearView.js
@@ -60,10 +60,9 @@ export function YearView({
             </div>
 
             {selectedEvents.length > 0 ? (
-              <div className="mt-2 max-h-28 space-y-1 overflow-y-auto">
-                {selectedEvents.map((event) => (
+                {selectedEvents.map((event, index) => (
                   <EventRow
-                    key={event.id}
+                    key={event.id || event._id || `${selectedDateKey}-${index}`}
                     event={event}
                     onSelect={onSelectEvent}
                     isAdminView={isAdminView}

--- a/src/Pages/Events/Calendar/calendarConstants.js
+++ b/src/Pages/Events/Calendar/calendarConstants.js
@@ -5,5 +5,9 @@ export const MONTHS = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
 
-const currentYear = new Date().getFullYear();
-export const YEAR_RANGE = Array.from({ length: 10 }, (_, i) => currentYear + i);
+export const VIEW_MODES = [
+  { label: 'Day', value: 'day' },
+  { label: 'Week', value: 'week' },
+  { label: 'Month', value: 'month' },
+  { label: 'Year', value: 'year' },
+];

--- a/src/Pages/Events/Calendar/calendarUtils.js
+++ b/src/Pages/Events/Calendar/calendarUtils.js
@@ -281,6 +281,26 @@ export function stepCursor(view, cursor, direction) {
 export function viewTitle(view, cursor) {
   if (view === 'day') return formatDate(toDateKey(cursor));
   if (view === 'year') return String(cursor.getFullYear());
+  if (view === 'week') {
+    const weekStart = new Date(
+      cursor.getFullYear(),
+      cursor.getMonth(),
+      cursor.getDate() - cursor.getDay(),
+    );
+    const weekEnd = new Date(
+      weekStart.getFullYear(),
+      weekStart.getMonth(),
+      weekStart.getDate() + 6,
+    );
+
+    if (weekStart.getFullYear() !== weekEnd.getFullYear()) {
+      return `${MONTHS[weekStart.getMonth()]} ${weekStart.getFullYear()} - ${MONTHS[weekEnd.getMonth()]} ${weekEnd.getFullYear()}`;
+    }
+    if (weekStart.getMonth() !== weekEnd.getMonth()) {
+      return `${MONTHS[weekStart.getMonth()]} - ${MONTHS[weekEnd.getMonth()]} ${weekEnd.getFullYear()}`;
+    }
+    return `${MONTHS[weekStart.getMonth()]} ${weekStart.getFullYear()}`;
+  }
   return `${MONTHS[cursor.getMonth()]} ${cursor.getFullYear()}`;
 }
 

--- a/src/Pages/Events/Calendar/calendarUtils.js
+++ b/src/Pages/Events/Calendar/calendarUtils.js
@@ -1,5 +1,6 @@
 import { membershipState } from '../../../Enums';
 import { toDateKey } from '../eventUtils';
+import { MONTHS } from './calendarConstants';
 
 export function eventDateKey(event) {
   if (!event.date) return null;
@@ -227,4 +228,125 @@ export function canUserManageEvent(event, user) {
   }
 
   return false;
+}
+
+export function visibleRange(view, cursor) {
+  const year = cursor.getFullYear();
+  const month = cursor.getMonth();
+  const day = cursor.getDate();
+  let start;
+  let end;
+
+  switch (view) {
+  case 'day':
+    start = new Date(year, month, day);
+    end = new Date(year, month, day);
+    break;
+  case 'week':
+    start = new Date(year, month, day - cursor.getDay());
+    end = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 6);
+    break;
+  case 'year':
+    start = new Date(year, 0, 1);
+    end = new Date(year, 11, 31);
+    break;
+  default:
+    start = new Date(year, month, 1);
+    end = new Date(year, month + 1, 0);
+  }
+
+  return {
+    startDate: toDateKey(start),
+    endDate: toDateKey(end),
+  };
+}
+
+export function stepCursor(view, cursor, direction) {
+  const year = cursor.getFullYear();
+  const month = cursor.getMonth();
+  const day = cursor.getDate();
+
+  switch (view) {
+  case 'day':
+    return new Date(year, month, day + direction);
+  case 'week':
+    return new Date(year, month, day + (7 * direction));
+  case 'year':
+    return new Date(year + direction, month, 1);
+  default:
+    return new Date(year, month + direction, 1);
+  }
+}
+
+export function viewTitle(view, cursor) {
+  if (view === 'day') return formatDate(toDateKey(cursor));
+  if (view === 'year') return String(cursor.getFullYear());
+  return `${MONTHS[cursor.getMonth()]} ${cursor.getFullYear()}`;
+}
+
+export function countLabel(view) {
+  switch (view) {
+  case 'day':
+    return 'today';
+  case 'week':
+    return 'this week';
+  case 'year':
+    return 'this year';
+  default:
+    return 'this month';
+  }
+}
+
+export function bucketEventsByHour(events) {
+  const allDayEvents = [];
+  const eventsByHour = Array.from({ length: 24 }, () => []);
+
+  events.forEach((event) => {
+    const validTime = /^(?:[01]\d|2[0-3]):[0-5]\d$/.test(String(event?.time || ''));
+    const timeValue = toTimeSortValue(event);
+
+    if (!validTime || !Number.isFinite(timeValue)) {
+      allDayEvents.push(event);
+      return;
+    }
+
+    eventsByHour[Math.floor(timeValue / 60)].push(event);
+  });
+
+  return { allDayEvents, eventsByHour };
+}
+
+export function miniMonthMatrix(year, month) {
+  const firstDayOffset = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const totalCells = Math.ceil((firstDayOffset + daysInMonth) / 7) * 7;
+  return Array.from({ length: totalCells }, (_, index) => {
+    const day = index - firstDayOffset + 1;
+    return day >= 1 && day <= daysInMonth
+      ? new Date(year, month, day)
+      : null;
+  });
+}
+
+export function calendarSearchParams(search, cursor, view) {
+  const params = new URLSearchParams(search);
+  const month = cursor.getMonth();
+  const year = cursor.getFullYear();
+
+  params.set('month', month);
+  params.set('year', year);
+
+  if (view === 'month') {
+    params.delete('view');
+  } else {
+    params.set('view', view);
+  }
+
+  if (view === 'day' || view === 'week') {
+    params.set('day', cursor.getDate());
+  } else {
+    params.delete('day');
+  }
+
+  return params;
 }

--- a/src/Pages/Events/EventIcons.js
+++ b/src/Pages/Events/EventIcons.js
@@ -14,6 +14,14 @@ export function ChevronRight() {
   );
 }
 
+export function ChevronDown() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M19 9l-7 7-7-7" />
+    </svg>
+  );
+}
+
 export function CalendarIcon() {
   return (
     <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -8,41 +8,6 @@ import { VIEW_MODES } from './Calendar/calendarConstants';
 import { calendarSearchParams, visibleRange } from './Calendar/calendarUtils';
 
 const EVENTS_CALENDAR_CURSOR_KEY = 'scevents-calendar-cursor';
-// Temporary Year-view preview events. Remove this block when preview is no longer needed.
-const YEAR_VIEW_PREVIEW_EVENTS = [
-  {
-    id: 'year-preview-2026-08-12',
-    name: 'Preview: Design review',
-    date: '2026-08-12',
-    time: '10:00',
-    status: 'published',
-    visibility: 'public',
-  },
-  {
-    id: 'year-preview-2026-09-01',
-    name: 'Preview: Project kickoff',
-    date: '2026-09-01',
-    time: '14:00',
-    status: 'published',
-    visibility: 'public',
-  },
-  {
-    id: 'year-preview-2026-09-03',
-    name: 'Preview: Member workshop',
-    date: '2026-09-03',
-    time: '18:00',
-    status: 'published',
-    visibility: 'public',
-  },
-  {
-    id: 'year-preview-2026-12-15',
-    name: 'Preview: End-of-year social',
-    date: '2026-12-15',
-    time: '17:30',
-    status: 'published',
-    visibility: 'public',
-  },
-];
 
 function canUserSeeEvent(event, user) {
   const userId = user?._id != null ? String(user._id) : '';
@@ -153,11 +118,6 @@ export default function EventsPage() {
 
   const isAdminView = user?.accessLevel >= membershipState.OFFICER;
   const visibleEvents = events.filter((event) => canUserSeeEvent(event, user));
-  const showYearPreview = view === 'year'
-    && new URLSearchParams(location.search).get('calendarPreview') === 'year';
-  const calendarEvents = showYearPreview
-    ? [...visibleEvents, ...YEAR_VIEW_PREVIEW_EVENTS]
-    : visibleEvents;
   const pageContainerClass = isAdminView
     ? 'relative h-dvh overflow-hidden bg-gradient-to-r from-gray-800 to-gray-600 text-white'
     : 'relative h-[calc(100dvh-4rem)] overflow-hidden bg-gradient-to-r from-gray-800 to-gray-600 text-white';
@@ -232,7 +192,7 @@ export default function EventsPage() {
 
         {!isLoading && !hasError && (
           <CalendarView
-            events={calendarEvents}
+            events={visibleEvents}
             isAdminView={isAdminView}
             user={user}
             canCreateEvent={isAdminView}

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -8,6 +8,41 @@ import { VIEW_MODES } from './Calendar/calendarConstants';
 import { calendarSearchParams, visibleRange } from './Calendar/calendarUtils';
 
 const EVENTS_CALENDAR_CURSOR_KEY = 'scevents-calendar-cursor';
+// Temporary Year-view preview events. Remove this block when preview is no longer needed.
+const YEAR_VIEW_PREVIEW_EVENTS = [
+  {
+    id: 'year-preview-2026-08-12',
+    name: 'Preview: Design review',
+    date: '2026-08-12',
+    time: '10:00',
+    status: 'published',
+    visibility: 'public',
+  },
+  {
+    id: 'year-preview-2026-09-01',
+    name: 'Preview: Project kickoff',
+    date: '2026-09-01',
+    time: '14:00',
+    status: 'published',
+    visibility: 'public',
+  },
+  {
+    id: 'year-preview-2026-09-03',
+    name: 'Preview: Member workshop',
+    date: '2026-09-03',
+    time: '18:00',
+    status: 'published',
+    visibility: 'public',
+  },
+  {
+    id: 'year-preview-2026-12-15',
+    name: 'Preview: End-of-year social',
+    date: '2026-12-15',
+    time: '17:30',
+    status: 'published',
+    visibility: 'public',
+  },
+];
 
 function canUserSeeEvent(event, user) {
   const userId = user?._id != null ? String(user._id) : '';
@@ -111,15 +146,25 @@ export default function EventsPage() {
     return new Date(today.getFullYear(), today.getMonth(), today.getDate());
   });
 
+  function handleYearMonthSelect(month) {
+    setCursor(new Date(cursor.getFullYear(), month, 1));
+    setView('month');
+  }
+
   const isAdminView = user?.accessLevel >= membershipState.OFFICER;
   const visibleEvents = events.filter((event) => canUserSeeEvent(event, user));
+  const showYearPreview = view === 'year'
+    && new URLSearchParams(location.search).get('calendarPreview') === 'year';
+  const calendarEvents = showYearPreview
+    ? [...visibleEvents, ...YEAR_VIEW_PREVIEW_EVENTS]
+    : visibleEvents;
   const pageContainerClass = isAdminView
     ? 'relative h-dvh overflow-hidden bg-gradient-to-r from-gray-800 to-gray-600 text-white'
     : 'relative h-[calc(100dvh-4rem)] overflow-hidden bg-gradient-to-r from-gray-800 to-gray-600 text-white';
   const calendarContainerClass = isAdminView
     ? 'relative h-full w-full overflow-hidden px-3 py-4 sm:px-4 sm:py-5 lg:px-5'
     : 'relative mx-auto h-full max-w-[120rem] overflow-y-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-10';
-  const fetchView = view === 'day' || view === 'week' ? view : 'month';
+  const fetchView = view === 'day' || view === 'week' || view === 'year' ? view : 'month';
 
   useEffect(() => {
     const params = calendarSearchParams(location.search, cursor, view);
@@ -187,7 +232,7 @@ export default function EventsPage() {
 
         {!isLoading && !hasError && (
           <CalendarView
-            events={visibleEvents}
+            events={calendarEvents}
             isAdminView={isAdminView}
             user={user}
             canCreateEvent={isAdminView}
@@ -195,6 +240,7 @@ export default function EventsPage() {
             setCursor={setCursor}
             view={view}
             onViewChange={setView}
+            onYearMonthSelect={handleYearMonthSelect}
           />
         )}
       </div>

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -119,7 +119,7 @@ export default function EventsPage() {
   const calendarContainerClass = isAdminView
     ? 'relative h-full w-full overflow-hidden px-3 py-4 sm:px-4 sm:py-5 lg:px-5'
     : 'relative mx-auto h-full max-w-[120rem] overflow-y-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-10';
-  const fetchView = view === 'day' ? 'day' : 'month';
+  const fetchView = view === 'day' || view === 'week' ? view : 'month';
 
   useEffect(() => {
     const params = calendarSearchParams(location.search, cursor, view);

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -5,8 +5,7 @@ import { useSCE } from '../../Components/context/SceContext';
 import { membershipState } from '../../Enums';
 import CalendarView from './Calendar/CalendarView';
 import { VIEW_MODES } from './Calendar/calendarConstants';
-import { calendarSearchParams } from './Calendar/calendarUtils';
-import { toDateKey } from './eventUtils';
+import { calendarSearchParams, visibleRange } from './Calendar/calendarUtils';
 
 const EVENTS_CALENDAR_CURSOR_KEY = 'scevents-calendar-cursor';
 
@@ -120,6 +119,7 @@ export default function EventsPage() {
   const calendarContainerClass = isAdminView
     ? 'relative h-full w-full overflow-hidden px-3 py-4 sm:px-4 sm:py-5 lg:px-5'
     : 'relative mx-auto h-full max-w-[120rem] overflow-y-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-10';
+  const fetchView = view === 'day' ? 'day' : 'month';
 
   useEffect(() => {
     const params = calendarSearchParams(location.search, cursor, view);
@@ -137,13 +137,16 @@ export default function EventsPage() {
   }, [cursor, history, location.search, view]);
 
   useEffect(() => {
+    let isCurrent = true;
+
     async function fetchEvents() {
       setIsLoading(true);
       setHasError(false);
 
-      const startDate = toDateKey(new Date(cursor.getFullYear(), cursor.getMonth(), 1));
-      const endDate = toDateKey(new Date(cursor.getFullYear(), cursor.getMonth() + 1, 0));
+      const { startDate, endDate } = visibleRange(fetchView, cursor);
       const response = await getAllSCEvents(token, { startDate, endDate });
+
+      if (!isCurrent) return;
 
       if (!response.error) {
         setEvents(Array.isArray(response.responseData) ? response.responseData : []);
@@ -155,7 +158,10 @@ export default function EventsPage() {
     }
 
     fetchEvents();
-  }, [cursor, token]);
+    return () => {
+      isCurrent = false;
+    };
+  }, [cursor, fetchView, token]);
 
   return (
     <div className={pageContainerClass}>

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -4,6 +4,7 @@ import { getAllSCEvents } from '../../APIFunctions/SCEvents';
 import { useSCE } from '../../Components/context/SceContext';
 import { membershipState } from '../../Enums';
 import CalendarView from './Calendar/CalendarView';
+import { VIEW_MODES } from './Calendar/calendarConstants';
 import { toDateKey } from './eventUtils';
 
 const EVENTS_CALENDAR_CURSOR_KEY = 'scevents-calendar-cursor';
@@ -48,6 +49,15 @@ export default function EventsPage() {
   const [hasError, setHasError] = useState(false);
   const location = useLocation();
   const history = useHistory();
+
+  const [view, setView] = useState(() => {
+    const params = new URLSearchParams(location.search);
+    const viewParam = params.get('view');
+
+    return VIEW_MODES.some(({ value }) => value === viewParam)
+      ? viewParam
+      : 'month';
+  });
 
   const [cursor, setCursor] = useState(() => {
     const params = new URLSearchParams(location.search);
@@ -110,6 +120,12 @@ export default function EventsPage() {
     params.set('month', month);
     params.set('year', year);
 
+    if (view === 'month') {
+      params.delete('view');
+    } else {
+      params.set('view', view);
+    }
+
     window.localStorage.setItem(
       EVENTS_CALENDAR_CURSOR_KEY,
       JSON.stringify({ month, year }),
@@ -118,7 +134,7 @@ export default function EventsPage() {
     history.replace({
       search: params.toString(),
     });
-  }, [cursor, history, location.search]);
+  }, [cursor, history, location.search, view]);
 
   useEffect(() => {
     async function fetchEvents() {
@@ -171,6 +187,8 @@ export default function EventsPage() {
             canCreateEvent={isAdminView}
             cursor={cursor}
             setCursor={setCursor}
+            view={view}
+            onViewChange={setView}
           />
         )}
       </div>

--- a/src/Pages/Events/Events.js
+++ b/src/Pages/Events/Events.js
@@ -5,6 +5,7 @@ import { useSCE } from '../../Components/context/SceContext';
 import { membershipState } from '../../Enums';
 import CalendarView from './Calendar/CalendarView';
 import { VIEW_MODES } from './Calendar/calendarConstants';
+import { calendarSearchParams } from './Calendar/calendarUtils';
 import { toDateKey } from './eventUtils';
 
 const EVENTS_CALENDAR_CURSOR_KEY = 'scevents-calendar-cursor';
@@ -63,9 +64,11 @@ export default function EventsPage() {
     const params = new URLSearchParams(location.search);
     const monthParam = params.get('month');
     const yearParam = params.get('year');
+    const dayParam = params.get('day');
 
     const month = Number(monthParam);
     const year = Number(yearParam);
+    const day = Number(dayParam);
 
     if (
       monthParam !== null &&
@@ -75,7 +78,13 @@ export default function EventsPage() {
       month <= 11 &&
       Number.isInteger(year)
     ) {
-      return new Date(year, month, 1);
+      const daysInMonth = new Date(year, month + 1, 0).getDate();
+      const validDay = dayParam !== null &&
+        Number.isInteger(day) &&
+        day >= 1 &&
+        day <= daysInMonth;
+
+      return new Date(year, month, validDay ? day : 1);
     }
 
     const savedCursor = window.localStorage.getItem(EVENTS_CALENDAR_CURSOR_KEY);
@@ -100,7 +109,7 @@ export default function EventsPage() {
     }
 
     const today = new Date();
-    return new Date(today.getFullYear(), today.getMonth(), 1);
+    return new Date(today.getFullYear(), today.getMonth(), today.getDate());
   });
 
   const isAdminView = user?.accessLevel >= membershipState.OFFICER;
@@ -113,18 +122,9 @@ export default function EventsPage() {
     : 'relative mx-auto h-full max-w-[120rem] overflow-y-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-10';
 
   useEffect(() => {
-    const params = new URLSearchParams(location.search);
+    const params = calendarSearchParams(location.search, cursor, view);
     const month = cursor.getMonth();
     const year = cursor.getFullYear();
-
-    params.set('month', month);
-    params.set('year', year);
-
-    if (view === 'month') {
-      params.delete('view');
-    } else {
-      params.set('view', view);
-    }
 
     window.localStorage.setItem(
       EVENTS_CALENDAR_CURSOR_KEY,

--- a/test/frontend/CalendarViewModes.test.js
+++ b/test/frontend/CalendarViewModes.test.js
@@ -1,0 +1,163 @@
+import { expect } from 'chai';
+
+import {
+  bucketEventsByHour,
+  calendarSearchParams,
+  countLabel,
+  miniMonthMatrix,
+  stepCursor,
+  viewTitle,
+  visibleRange,
+} from '../../src/Pages/Events/Calendar/calendarUtils';
+
+function dateParts(date) {
+  return [date.getFullYear(), date.getMonth(), date.getDate()];
+}
+
+describe('Calendar view mode helpers', () => {
+  describe('visibleRange', () => {
+    it('returns inclusive day, week, month, and year ranges', () => {
+      expect(visibleRange('day', new Date(2026, 7, 27))).to.deep.equal({
+        startDate: '2026-08-27',
+        endDate: '2026-08-27',
+      });
+      expect(visibleRange('week', new Date(2026, 8, 2))).to.deep.equal({
+        startDate: '2026-08-30',
+        endDate: '2026-09-05',
+      });
+      expect(visibleRange('month', new Date(2028, 1, 14))).to.deep.equal({
+        startDate: '2028-02-01',
+        endDate: '2028-02-29',
+      });
+      expect(visibleRange('year', new Date(2026, 7, 27))).to.deep.equal({
+        startDate: '2026-01-01',
+        endDate: '2026-12-31',
+      });
+    });
+  });
+
+  describe('stepCursor', () => {
+    it('steps day and week views across month boundaries', () => {
+      expect(dateParts(stepCursor('day', new Date(2026, 7, 31), 1)))
+        .to.deep.equal([2026, 8, 1]);
+      expect(dateParts(stepCursor('day', new Date(2026, 7, 1), -1)))
+        .to.deep.equal([2026, 6, 31]);
+      expect(dateParts(stepCursor('week', new Date(2026, 7, 30), 1)))
+        .to.deep.equal([2026, 8, 6]);
+      expect(dateParts(stepCursor('week', new Date(2026, 7, 30), -1)))
+        .to.deep.equal([2026, 7, 23]);
+    });
+
+    it('anchors month and year steps to day one without mutating the cursor', () => {
+      const monthCursor = new Date(2026, 0, 31);
+      const yearCursor = new Date(2028, 1, 29);
+
+      expect(dateParts(stepCursor('month', monthCursor, 1)))
+        .to.deep.equal([2026, 1, 1]);
+      expect(dateParts(stepCursor('year', yearCursor, 1)))
+        .to.deep.equal([2029, 1, 1]);
+      expect(dateParts(monthCursor)).to.deep.equal([2026, 0, 31]);
+      expect(dateParts(yearCursor)).to.deep.equal([2028, 1, 29]);
+    });
+  });
+
+  describe('view labels', () => {
+    it('formats titles and count labels for all four views', () => {
+      const cursor = new Date(2026, 7, 27);
+      const crossMonthWeekCursor = new Date(2026, 8, 2);
+
+      expect(viewTitle('day', cursor)).to.equal('Thursday, August 27, 2026');
+      expect(viewTitle('week', crossMonthWeekCursor)).to.equal('September 2026');
+      expect(viewTitle('month', cursor)).to.equal('August 2026');
+      expect(viewTitle('year', cursor)).to.equal('2026');
+      expect(countLabel('day')).to.equal('today');
+      expect(countLabel('week')).to.equal('this week');
+      expect(countLabel('month')).to.equal('this month');
+      expect(countLabel('year')).to.equal('this year');
+    });
+  });
+
+  describe('bucketEventsByHour', () => {
+    it('keeps timed events ordered and moves invalid times to all day', () => {
+      const midnight = { name: 'Midnight', time: '00:00' };
+      const firstMorning = { name: 'Z first', time: '09:30' };
+      const secondMorning = { name: 'A second', time: '09:30' };
+      const late = { name: 'Late', time: '23:59' };
+      const untimed = { name: 'Untimed' };
+      const malformed = { name: 'Malformed', time: 'morning' };
+      const outOfRange = { name: 'Out of range', time: '24:00' };
+      const badMinute = { name: 'Bad minute', time: '12:99' };
+      const missingMinute = { name: 'Missing minute', time: '09:' };
+      const result = bucketEventsByHour([
+        midnight,
+        firstMorning,
+        secondMorning,
+        late,
+        untimed,
+        malformed,
+        outOfRange,
+        badMinute,
+        missingMinute,
+      ]);
+
+      expect(result.eventsByHour).to.have.lengthOf(24);
+      expect(new Set(result.eventsByHour).size).to.equal(24);
+      expect(result.eventsByHour[0]).to.deep.equal([midnight]);
+      expect(result.eventsByHour[9]).to.deep.equal([firstMorning, secondMorning]);
+      expect(result.eventsByHour[23]).to.deep.equal([late]);
+      expect(result.allDayEvents)
+        .to.deep.equal([untimed, malformed, outOfRange, badMinute, missingMinute]);
+    });
+  });
+
+  describe('miniMonthMatrix', () => {
+    it('builds a Sunday-start leap-February matrix with complete weeks', () => {
+      const matrix = miniMonthMatrix(2028, 1);
+      const dates = matrix.filter(Boolean);
+
+      expect(matrix).to.have.lengthOf(35);
+      expect(matrix[0]).to.equal(null);
+      expect(matrix[1]).to.equal(null);
+      expect(dateParts(matrix[2])).to.deep.equal([2028, 1, 1]);
+      expect(dateParts(matrix[30])).to.deep.equal([2028, 1, 29]);
+      expect(matrix.slice(31)).to.deep.equal([null, null, null, null]);
+      expect(dates).to.have.lengthOf(29);
+    });
+  });
+
+  describe('calendarSearchParams', () => {
+    const cursor = new Date(2026, 7, 27);
+
+    it('keeps Month URLs free of view and day parameters', () => {
+      const params = calendarSearchParams(
+        '?month=7&year=2026&view=day&day=12',
+        cursor,
+        'month',
+      );
+
+      expect(params.toString()).to.equal('month=7&year=2026');
+      expect(params.has('view')).to.equal(false);
+      expect(params.has('day')).to.equal(false);
+    });
+
+    it('writes day only for Day and Week while preserving unrelated parameters', () => {
+      const dayParams = calendarSearchParams('?filter=mine', cursor, 'day');
+      const weekParams = calendarSearchParams('?filter=mine', cursor, 'week');
+      const yearParams = calendarSearchParams('?filter=mine&day=12', cursor, 'year');
+
+      expect(dayParams.get('month')).to.equal('7');
+      expect(dayParams.get('year')).to.equal('2026');
+      expect(dayParams.get('view')).to.equal('day');
+      expect(dayParams.get('day')).to.equal('27');
+      expect(dayParams.get('filter')).to.equal('mine');
+      expect(weekParams.get('month')).to.equal('7');
+      expect(weekParams.get('year')).to.equal('2026');
+      expect(weekParams.get('view')).to.equal('week');
+      expect(weekParams.get('day')).to.equal('27');
+      expect(weekParams.get('filter')).to.equal('mine');
+      expect(yearParams.get('view')).to.equal('year');
+      expect(yearParams.has('day')).to.equal(false);
+      expect(yearParams.get('filter')).to.equal('mine');
+    });
+  });
+});

--- a/test/frontend/CalendarViewModes.test.js
+++ b/test/frontend/CalendarViewModes.test.js
@@ -65,9 +65,12 @@ describe('Calendar view mode helpers', () => {
     it('formats titles and count labels for all four views', () => {
       const cursor = new Date(2026, 7, 27);
       const crossMonthWeekCursor = new Date(2026, 8, 2);
+      const crossYearWeekCursor = new Date(2026, 11, 30);
 
       expect(viewTitle('day', cursor)).to.equal('Thursday, August 27, 2026');
-      expect(viewTitle('week', crossMonthWeekCursor)).to.equal('September 2026');
+      expect(viewTitle('week', cursor)).to.equal('August 2026');
+      expect(viewTitle('week', crossMonthWeekCursor)).to.equal('August - September 2026');
+      expect(viewTitle('week', crossYearWeekCursor)).to.equal('December 2026 - January 2027');
       expect(viewTitle('month', cursor)).to.equal('August 2026');
       expect(viewTitle('year', cursor)).to.equal('2026');
       expect(countLabel('day')).to.equal('today');


### PR DESCRIPTION
## Summary

This pull request adds Day, Week, and Year views to the Events calendar for Issue #2160, while preserving the existing Month view structure and behavior. The calendar now supports switching between all four views from a single selector, uses view-aware navigation and titles, and keeps the current calendar cursor synchronized with the existing URL parameters.

The goal is to make calendar navigation more useful without changing the SCEvents API, database behavior, event visibility rules, or existing Month view rendering.

## Calendar view improvements

### Shared navigation and state

- Added Day, Week, Month, and Year options to the calendar view selector.
- Added view-aware previous, next, and Today navigation behavior.
- Added dynamic calendar titles:
  - Day view shows the full weekday and date.
  - Week view supports same-month, cross-month, and cross-year titles.
  - Month view shows the current month and year.
  - Year view shows the current year.
- Added view-aware event-count labels such as “today,” “this week,” and “this year.”
- Preserved the existing Month URL and localStorage behavior so Month remains compatible with the existing calendar flow.

### Day and Week views

- Added an hourly Day view using the existing event pill and popup behavior.
- Added a seven-column Week view with Sunday through Saturday columns.
- Timed events are placed into their start-hour rows.
- Events without valid times are placed in the all-day area.
- Week view supports weeks that cross month and year boundaries.
- Mobile Week view remains horizontally scrollable rather than compressing the seven-day layout.

### Year view

- Added a Year view with twelve Sunday-start mini-months.
- Year view uses three mini-months per desktop row and one per mobile row.
- Month headings are centered within each mini-month card and remain clickable.
- Clicking a month heading opens the existing Month view for that month.
- Clicking a day keeps the user in Year view and opens an in-place preview of that date’s events.
- Clicking another day updates the preview, while clicking unused mini-month space dismisses it.
- Selecting an event from the preview continues to use the existing event popup.
- The Today button keeps the user in Year view and scrolls to the mini-month containing today.
- Event dots are shown only for visible events.
- Date cells reserve the same event-dot space whether or not they have an event, keeping all date numbers vertically aligned.
- Today indicators and event dots have additional spacing so they do not overlap.

## Scope and compatibility

- No SCEvents API, database, Docker, routing, or dependency changes were made.
- No temporary preview-event fixtures or preview query handling remain in source.
- Existing Month calendar components and event popup behavior remain unchanged.
- Persisting a user’s chosen calendar view remains outside this pull request.

## Verification

- `npm run lint`
- `TZ=UTC npm run frontend-test`
- `TZ=America/Los_Angeles npm run frontend-test`
- Focused mounted checks for Day, Week, and Year interactions.
- Focused checks for Year-view Today scrolling, in-place date previews, event-dot alignment, blank-space dismissal, and temporary preview-event removal.

## Screenshots

- Day View
<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/9fbb297f-be5b-43b2-bee7-0e8877a36e2f" />

- Week View
<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/b44329c7-dce2-4d07-adeb-92fdfb9e25a2" />

- Year View
<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/9bb1a002-ff92-46f7-9b5c-a97fe4b4e44c" />