### PR TITLE
Add E-Board introduction section to SCE About Us page

### DIFF
--- a/src/Pages/About/About.js
+++ b/src/Pages/About/About.js
@@ -27,6 +27,13 @@ function useScrollSpy() {
   return activeId;
 }
 
+const eboardDetails = [
+  { role: 'President', name: 'Cindy Tat', discord: '_c1ndytat' },
+  { role: 'Vice President', name: 'Wesley Wong', discord: 'weslayer' },
+  { role: 'Treasurer', name: 'Gerard Consuelo', discord: 'epicgdog' },
+  { role: 'EP/PR Chair', name: 'Rachel Tran', discord: 'ra2y' },
+];
+
 export default function AboutPage() {
   const activeId = useScrollSpy();
 
@@ -63,6 +70,21 @@ export default function AboutPage() {
                 <li>• Collaborative workspace and community</li>
                 <li>• Professional development workshops</li>
               </ul>
+            </div>
+          </section>
+
+          <section id="eboard" data-spy className="space-y-6">
+            <h2 className="text-2xl font-semibold text-gray-900 md:text-3xl dark:text-gray-100">Our Team</h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {eboardDetails.map((entry) => (
+                <div key={entry.role} className="p-6 bg-gray-50 rounded-lg border border-black dark:bg-gray-800 dark:border-white">
+                  <h3 className="mb-3 font-semibold text-gray-900 dark:text-gray-100">{entry.role}</h3>
+                  <div className="space-y-1 text-sm">
+                    <p>{entry.name}</p>
+                    <p>Discord: <span className="font-mono">{entry.discord}</span></p>
+                  </div>
+                </div>
+              ))}
             </div>
           </section>
 
@@ -230,6 +252,15 @@ export default function AboutPage() {
                   ].join(' ')}
                 >
                   Introduction
+                </button>
+                <button
+                  onClick={() => scrollToSection('eboard')}
+                  className={[
+                    'block w-full text-sm text-left transition-colors hover:text-blue-600 dark:hover:text-blue-400'
+                    , activeId === 'eboard' ? 'font-bold text-blue-600 dark:text-blue-400' : 'text-gray-600 dark:text-gray-400'
+                  ].join(' ')}
+                >
+                  Our Team
                 </button>
                 <button
                   onClick={() => scrollToSection('location')}

--- a/test/frontend/AboutPage.test.js
+++ b/test/frontend/AboutPage.test.js
@@ -65,8 +65,8 @@ describe('<AboutPage />', () => {
     const tocButtons = tocNav.find('button');
     expect(tocButtons.length).to.be.greaterThan(0);
     expect(tocButtons.at(0).text()).to.equal('Introduction');
-    expect(tocButtons.at(1).text()).to.equal('Location & Hours');
-    expect(tocButtons.at(2).text()).to.equal('Membership');
+    expect(tocButtons.at(1).text()).to.equal('Our Team');
+    expect(tocButtons.at(2).text()).to.equal('Location & Hours');
   });
 
   it('Should have responsive text sizing', () => {


### PR DESCRIPTION
## Motivation

New SCE members sometimes have trouble identifying who's who in the SCE Discord. 

## Implementation

This PR adds a section to the SCE "About" page to introduce the members of the executive board + their discord handles, so people can reach them easier.